### PR TITLE
Implement User, Team, and TeamMember services and controllers

### DIFF
--- a/backend/XActBackend.Core/Services/GameSessionService.cs
+++ b/backend/XActBackend.Core/Services/GameSessionService.cs
@@ -27,12 +27,12 @@ public interface IGameSessionService
 
 internal sealed class GameSessionService(IUnitOfWork uow) : IGameSessionService
 {
-    private static int _nextSessionId = 6;
 
     public async ValueTask<IReadOnlyCollection<GameSession>> GetAllGameSessionsAsync(bool tracking)
     {
         IEnumerable<GameSession> gameSessions = await uow.GameSessionRepository.GetAllSessionsAsync(tracking);
 
+        // TODO: avoid unnecessary copy, use IReadOnlyCollection<GameSession> directly
         return [.. gameSessions];
     }
 
@@ -47,19 +47,16 @@ internal sealed class GameSessionService(IUnitOfWork uow) : IGameSessionService
     {
         try
         {
-            var gameSession = new GameSession
-            {
-                Id = _nextSessionId++,
-                HostUserId = newGameSession.HostUserId,
-                JoinCode = newGameSession.JoinCode,
-                Status = newGameSession.Status,
-                StartTime = newGameSession.StartTime,
-                EndTime = newGameSession.EndTime,
-                PlannedDurationMinutes = newGameSession.PlannedDurationMinutes,
-                MrXRevealInterval = newGameSession.MrXRevealInterval
-            };
+            var gameSession = uow.GameSessionRepository.AddGameSession(
+                newGameSession.HostUserId,
+                newGameSession.JoinCode,
+                newGameSession.PlannedDurationMinutes,
+                newGameSession.MrXRevealInterval
+            );
 
-            uow.GameSessionRepository.AddGameSession(gameSession.HostUserId, gameSession.JoinCode, gameSession.PlannedDurationMinutes, gameSession.MrXRevealInterval);
+            gameSession.Status = newGameSession.Status;
+            gameSession.StartTime = newGameSession.StartTime;
+            gameSession.EndTime = newGameSession.EndTime;
 
             await uow.SaveChangesAsync();
 

--- a/backend/XActBackend.Core/Services/TeamMemberService.cs
+++ b/backend/XActBackend.Core/Services/TeamMemberService.cs
@@ -1,0 +1,101 @@
+﻿using OneOf;
+using OneOf.Types;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+
+namespace XActBackend.Core.Services;
+
+public interface ITeamMemberService
+{
+    public ValueTask<IReadOnlyCollection<TeamMember>> GetMembersByTeamIdAsync(int teamId, bool tracking);
+    public ValueTask<OneOf<TeamMember, NotFound>> GetTeamMemberByIdAsync(int memberId, bool tracking);
+    public ValueTask<OneOf<TeamMember, Error>> AddTeamMemberAsync(TeamMemberData newTeamMember);
+    public ValueTask<OneOf<Success, NotFound>> UpdateTeamMemberAsync(int memberId, TeamMemberData teamMemberData, bool tracking);
+    public ValueTask<OneOf<Success, NotFound>> DeleteTeamMemberAsync(int memberId, bool tracking);
+
+    public sealed record TeamMemberData(
+        int TeamId,
+        int UserId,
+        bool IsTeamLeader = false,
+        double? CurrentLatitude = null,
+        double? CurrentLongitude = null,
+        Instant? LastUpdated = null
+    );
+}
+
+internal sealed class TeamMemberService(IUnitOfWork uow, IClock clock) : ITeamMemberService
+{
+    public async ValueTask<IReadOnlyCollection<TeamMember>> GetMembersByTeamIdAsync(int teamId, bool tracking)
+    {
+        IReadOnlyCollection<TeamMember> members = await uow.TeamMemberRepository.GetMembersByTeamIdAsync(teamId, tracking);
+
+        return members;
+    }
+
+    public async ValueTask<OneOf<TeamMember, NotFound>> GetTeamMemberByIdAsync(int memberId, bool tracking)
+    {
+        var member = await uow.TeamMemberRepository.GetMemberByIdAsync(memberId, tracking);
+
+        return member is not null ? member : new NotFound();
+    }
+
+    public async ValueTask<OneOf<TeamMember, Error>> AddTeamMemberAsync(ITeamMemberService.TeamMemberData newTeamMember)
+    {
+        try
+        {
+            var member = uow.TeamMemberRepository.AddTeamMember(
+                newTeamMember.TeamId,
+                newTeamMember.UserId,
+                newTeamMember.IsTeamLeader
+            );
+
+            member.CurrentLatitude = newTeamMember.CurrentLatitude;
+            member.CurrentLongitude = newTeamMember.CurrentLongitude;
+            member.LastUpdated = newTeamMember.LastUpdated ?? clock.GetCurrentInstant();
+
+            await uow.SaveChangesAsync();
+
+            return member;
+        }
+        catch (Exception)
+        {
+            return new Error();
+        }
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> UpdateTeamMemberAsync(int memberId, ITeamMemberService.TeamMemberData teamMemberData, bool tracking)
+    {
+        var member = await uow.TeamMemberRepository.GetMemberByIdAsync(memberId, tracking);
+
+        if (member is null)
+        {
+            return new NotFound();
+        }
+
+        member.TeamId = teamMemberData.TeamId;
+        member.UserId = teamMemberData.UserId;
+        member.IsTeamLeader = teamMemberData.IsTeamLeader;
+        member.CurrentLatitude = teamMemberData.CurrentLatitude;
+        member.CurrentLongitude = teamMemberData.CurrentLongitude;
+        member.LastUpdated = teamMemberData.LastUpdated ?? clock.GetCurrentInstant();
+
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> DeleteTeamMemberAsync(int memberId, bool tracking)
+    {
+        var member = await uow.TeamMemberRepository.GetMemberByIdAsync(memberId, tracking);
+
+        if (member is null)
+        {
+            return new NotFound();
+        }
+
+        uow.TeamMemberRepository.RemoveTeamMember(member);
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+}

--- a/backend/XActBackend.Core/Services/TeamService.cs
+++ b/backend/XActBackend.Core/Services/TeamService.cs
@@ -1,0 +1,98 @@
+﻿using OneOf;
+using OneOf.Types;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+
+namespace XActBackend.Core.Services;
+
+public interface ITeamService
+{
+    public ValueTask<IReadOnlyCollection<Team>> GetTeamsBySessionIdAsync(int sessionId, bool tracking);
+    public ValueTask<OneOf<Team, NotFound>> GetTeamByIdAsync(int teamId, bool tracking);
+    public ValueTask<OneOf<Team, Error>> AddTeamAsync(TeamData newTeam);
+    public ValueTask<OneOf<Success, NotFound>> UpdateTeamAsync(int teamId, TeamData teamData, bool tracking);
+    public ValueTask<OneOf<Success, NotFound>> DeleteTeamAsync(int teamId, bool tracking);
+
+    public sealed record TeamData(
+        int SessionId,
+        string TeamName,
+        TeamRole Role,
+        string ColorCode,
+        bool IsCaught = false
+    );
+}
+
+internal sealed class TeamService(IUnitOfWork uow) : ITeamService
+{
+    public async ValueTask<IReadOnlyCollection<Team>> GetTeamsBySessionIdAsync(int sessionId, bool tracking)
+    {
+        IReadOnlyCollection<Team> teams = await uow.TeamRepository.GetTeamsBySessionIdAsync(sessionId, tracking);
+
+        return teams;
+    }
+
+    public async ValueTask<OneOf<Team, NotFound>> GetTeamByIdAsync(int teamId, bool tracking)
+    {
+        var team = await uow.TeamRepository.GetTeamByIdAsync(teamId, tracking);
+
+        return team is not null ? team : new NotFound();
+    }
+
+    public async ValueTask<OneOf<Team, Error>> AddTeamAsync(ITeamService.TeamData newTeam)
+    {
+        try
+        {
+            var team = uow.TeamRepository.AddTeam(
+                newTeam.SessionId,
+                newTeam.TeamName,
+                newTeam.Role,
+                newTeam.ColorCode
+            );
+
+            team.IsCaught = newTeam.IsCaught;
+
+            await uow.SaveChangesAsync();
+
+            return team;
+        }
+        catch (Exception)
+        {
+            return new Error();
+        }
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> UpdateTeamAsync(int teamId, ITeamService.TeamData teamData, bool tracking)
+    {
+        var team = await uow.TeamRepository.GetTeamByIdAsync(teamId, tracking);
+
+        if (team is null)
+        {
+            return new NotFound();
+        }
+
+        team.SessionId = teamData.SessionId;
+        team.TeamName = teamData.TeamName;
+        team.Role = teamData.Role;
+        team.ColorCode = teamData.ColorCode;
+        team.IsCaught = teamData.IsCaught;
+
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> DeleteTeamAsync(int teamId, bool tracking)
+    {
+        var team = await uow.TeamRepository.GetTeamByIdAsync(teamId, tracking);
+
+        if (team is null)
+        {
+            return new NotFound();
+        }
+
+        uow.TeamRepository.RemoveTeam(team);
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+}

--- a/backend/XActBackend.Core/Services/UserService.cs
+++ b/backend/XActBackend.Core/Services/UserService.cs
@@ -1,0 +1,120 @@
+﻿using OneOf;
+using OneOf.Types;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+
+namespace XActBackend.Core.Services;
+
+public interface IUserService
+{
+    public ValueTask<IReadOnlyCollection<User>> GetAllUsersAsync(bool tracking);
+    public ValueTask<OneOf<User, NotFound>> GetUserByIdAsync(int userId, bool tracking);
+    public ValueTask<OneOf<User, NotFound>> GetUserByEmailAsync(string email, bool tracking);
+    public ValueTask<OneOf<User, NotFound>> GetUserByUsernameAsync(string username, bool tracking);
+    public ValueTask<OneOf<User, Error>> AddUserAsync(UserData newUser);
+    public ValueTask<OneOf<Success, NotFound>> UpdateUserAsync(int userId, UserData userData, bool tracking);
+    public ValueTask<OneOf<Success, NotFound>> DeleteUserAsync(int userId, bool tracking);
+
+    public sealed record UserData(
+        string Username,
+        string Email,
+        string PasswordHash,
+        AccountType AccountType = AccountType.Free,
+        Instant? SubscriptionEndDate = null,
+        int TotalWins = 0,
+        int TotalGamesPlayed = 0
+    );
+}
+
+internal sealed class UserService(IUnitOfWork uow) : IUserService
+{
+    public async ValueTask<IReadOnlyCollection<User>> GetAllUsersAsync(bool tracking)
+    {
+        IReadOnlyCollection<User> users = await uow.UserRepository.GetAllUsersAsync(tracking);
+
+        return users;
+    }
+
+    public async ValueTask<OneOf<User, NotFound>> GetUserByIdAsync(int userId, bool tracking)
+    {
+        var user = await uow.UserRepository.GetUserByIdAsync(userId, tracking);
+
+        return user is not null ? user : new NotFound();
+    }
+
+    public async ValueTask<OneOf<User, NotFound>> GetUserByEmailAsync(string email, bool tracking)
+    {
+        var user = await uow.UserRepository.GetUserByEmailAsync(email, tracking);
+
+        return user is not null ? user : new NotFound();
+    }
+
+    public async ValueTask<OneOf<User, NotFound>> GetUserByUsernameAsync(string username, bool tracking)
+    {
+        var user = await uow.UserRepository.GetUserByUsernameAsync(username, tracking);
+
+        return user is not null ? user : new NotFound();
+    }
+
+    public async ValueTask<OneOf<User, Error>> AddUserAsync(IUserService.UserData newUser)
+    {
+        try
+        {
+            var user = uow.UserRepository.AddUser(
+                newUser.Username,
+                newUser.Email,
+                newUser.PasswordHash,
+                newUser.AccountType
+            );
+
+            user.SubscriptionEndDate = newUser.SubscriptionEndDate;
+            user.TotalWins = newUser.TotalWins;
+            user.TotalGamesPlayed = newUser.TotalGamesPlayed;
+
+            await uow.SaveChangesAsync();
+
+            return user;
+        }
+        catch (Exception)
+        {
+            return new Error();
+        }
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> UpdateUserAsync(int userId, IUserService.UserData userData, bool tracking)
+    {
+        var user = await uow.UserRepository.GetUserByIdAsync(userId, tracking);
+
+        if (user is null)
+        {
+            return new NotFound();
+        }
+
+        user.Username = userData.Username;
+        user.Email = userData.Email;
+        user.PasswordHash = userData.PasswordHash;
+        user.AccountType = userData.AccountType;
+        user.SubscriptionEndDate = userData.SubscriptionEndDate;
+        user.TotalWins = userData.TotalWins;
+        user.TotalGamesPlayed = userData.TotalGamesPlayed;
+
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+
+    public async ValueTask<OneOf<Success, NotFound>> DeleteUserAsync(int userId, bool tracking)
+    {
+        var user = await uow.UserRepository.GetUserByIdAsync(userId, tracking);
+
+        if (user is null)
+        {
+            return new NotFound();
+        }
+
+        uow.UserRepository.RemoveUser(user);
+        await uow.SaveChangesAsync();
+
+        return new Success();
+    }
+}

--- a/backend/XActBackend.Core/Util/CoreSetup.cs
+++ b/backend/XActBackend.Core/Util/CoreSetup.cs
@@ -12,5 +12,8 @@ public static class CoreSetup
         services.AddScoped<IGeofencePointService, GeoFencePointService>();
         services.AddScoped<ILocationLogService, LocationLogService>();
         services.AddScoped<IPowerUpUsageService, PowerUpUsageService>();
+        services.AddScoped<IUserService, UserService>();
+        services.AddScoped<ITeamService, TeamService>();
+        services.AddScoped<ITeamMemberService, TeamMemberService>();
     }
 }

--- a/backend/XActBackend/Controllers/TeamController.cs
+++ b/backend/XActBackend/Controllers/TeamController.cs
@@ -1,0 +1,185 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OneOf;
+using OneOf.Types;
+using XActBackend.Core.Services;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+using XActBackend.Util;
+
+namespace XActBackend.Controllers;
+
+// TODO Review tracking usage
+
+[Route("api/gamesessions/{sessionId:int}/teams")]
+public sealed class TeamController(
+    ITransactionProvider transaction,
+    ITeamService teamService,
+    ILogger<TeamController> logger) : BaseController
+{
+    [HttpGet]
+    [Route("")]
+    [ProducesResponseType<TeamListResponse>(StatusCodes.Status200OK)]
+    public async ValueTask<ActionResult<TeamListResponse>> GetTeamsBySessionId([FromRoute] int sessionId)
+    {
+        IReadOnlyCollection<Team> teams = await teamService.GetTeamsBySessionIdAsync(sessionId, tracking: false);
+
+        return Ok(new TeamListResponse
+        {
+            Items = teams.Select(TeamInformationDto.FromTeam).ToList()
+        });
+    }
+
+    [HttpGet]
+    [Route("{teamId:int}")]
+    [ProducesResponseType<TeamDetailsDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<TeamDetailsDto>> GetTeamById(
+        [FromRoute] int sessionId,
+        [FromRoute] int teamId)
+    {
+        OneOf<Team, NotFound> teamResult = await teamService.GetTeamByIdAsync(teamId, tracking: false);
+
+        return teamResult.Match<ActionResult<TeamDetailsDto>>(
+            team => Ok(TeamDetailsDto.FromTeam(team)),
+            notFound => NotFound()
+        );
+    }
+
+    [HttpPost]
+    [Route("")]
+    [ProducesResponseType<TeamDetailsDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async ValueTask<IActionResult> AddTeam(
+        [FromRoute] int sessionId,
+        [FromBody] TeamAddRequest addRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Team, Error> addResult = await teamService.AddTeamAsync(
+                new ITeamService.TeamData(
+                    sessionId,
+                    addRequest.TeamName,
+                    addRequest.Role,
+                    addRequest.ColorCode,
+                    addRequest.IsCaught
+                )
+            );
+
+            return await addResult.Match<ValueTask<IActionResult>>(async team =>
+            {
+                await transaction.CommitAsync();
+                return CreatedAtAction(nameof(GetTeamById),
+                    new { sessionId, teamId = team.Id },
+                    TeamDetailsDto.FromTeam(team));
+            }, async error =>
+            {
+                await transaction.RollbackAsync();
+                return BadRequest();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to add team for session {SessionId}", sessionId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+
+    [HttpPut]
+    [Route("{teamId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> UpdateTeam(
+        [FromRoute] int sessionId,
+        [FromRoute] int teamId,
+        [FromBody] TeamUpdateRequest updateRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> updateResult = await teamService.UpdateTeamAsync(
+                teamId,
+                new ITeamService.TeamData(
+                    sessionId,
+                    updateRequest.TeamName,
+                    updateRequest.Role,
+                    updateRequest.ColorCode,
+                    updateRequest.IsCaught
+                ),
+                tracking: true
+            );
+
+            return await updateResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update team {TeamId} for session {SessionId}", teamId, sessionId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+
+    [HttpDelete]
+    [Route("{teamId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> DeleteTeam(
+        [FromRoute] int sessionId,
+        [FromRoute] int teamId)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> deleteResult = await teamService.DeleteTeamAsync(teamId, tracking: true);
+
+            return await deleteResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete team {TeamId} for session {SessionId}", teamId, sessionId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+}
+
+public sealed class TeamListResponse
+{
+    public required List<TeamInformationDto> Items { get; init; }
+}
+
+public sealed record TeamInformationDto(int Id, int SessionId, string TeamName, TeamRole Role, string ColorCode)
+{
+    public static TeamInformationDto FromTeam(Team team) =>
+        new(team.Id, team.SessionId, team.TeamName, team.Role, team.ColorCode);
+}
+
+public sealed record TeamDetailsDto(int Id, int SessionId, string TeamName, TeamRole Role, string ColorCode, bool IsCaught)
+{
+    public static TeamDetailsDto FromTeam(Team team) =>
+        new(team.Id, team.SessionId, team.TeamName, team.Role, team.ColorCode, team.IsCaught);
+}
+
+public sealed record TeamAddRequest(string TeamName, TeamRole Role, string ColorCode, bool IsCaught = false);
+
+public sealed record TeamUpdateRequest(string TeamName, TeamRole Role, string ColorCode, bool IsCaught);

--- a/backend/XActBackend/Controllers/TeamMemberController.cs
+++ b/backend/XActBackend/Controllers/TeamMemberController.cs
@@ -1,0 +1,207 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OneOf;
+using OneOf.Types;
+using XActBackend.Core.Services;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+using XActBackend.Util;
+
+namespace XActBackend.Controllers;
+
+// TODO Review tracking usage
+
+[Route("api/gamesessions/{sessionId:int}/teams/{teamId:int}/members")]
+public sealed class TeamMemberController(
+    ITransactionProvider transaction,
+    ITeamMemberService teamMemberService,
+    ILogger<TeamMemberController> logger) : BaseController
+{
+    [HttpGet]
+    [Route("")]
+    [ProducesResponseType<TeamMemberListResponse>(StatusCodes.Status200OK)]
+    public async ValueTask<ActionResult<TeamMemberListResponse>> GetMembersByTeamId([FromRoute] int teamId)
+    {
+        IReadOnlyCollection<TeamMember> members = await teamMemberService.GetMembersByTeamIdAsync(teamId, tracking: false);
+
+        return Ok(new TeamMemberListResponse
+        {
+            Items = members.Select(TeamMemberInformationDto.FromTeamMember).ToList()
+        });
+    }
+
+    [HttpGet]
+    [Route("{memberId:int}")]
+    [ProducesResponseType<TeamMemberDetailsDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<TeamMemberDetailsDto>> GetTeamMemberById(
+        [FromRoute] int teamId,
+        [FromRoute] int memberId)
+    {
+        OneOf<TeamMember, NotFound> memberResult = await teamMemberService.GetTeamMemberByIdAsync(memberId, tracking: false);
+
+        return memberResult.Match<ActionResult<TeamMemberDetailsDto>>(
+            member => Ok(TeamMemberDetailsDto.FromTeamMember(member)),
+            notFound => NotFound()
+        );
+    }
+
+    [HttpPost]
+    [Route("")]
+    [ProducesResponseType<TeamMemberDetailsDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async ValueTask<IActionResult> AddTeamMember(
+        [FromRoute] int teamId,
+        [FromBody] TeamMemberAddRequest addRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<TeamMember, Error> addResult = await teamMemberService.AddTeamMemberAsync(
+                new ITeamMemberService.TeamMemberData(
+                    teamId,
+                    addRequest.UserId,
+                    addRequest.IsTeamLeader,
+                    addRequest.CurrentLatitude,
+                    addRequest.CurrentLongitude,
+                    addRequest.LastUpdated
+                )
+            );
+
+            return await addResult.Match<ValueTask<IActionResult>>(async member =>
+            {
+                await transaction.CommitAsync();
+                return CreatedAtAction(nameof(GetTeamMemberById),
+                    new { teamId, memberId = member.Id },
+                    TeamMemberDetailsDto.FromTeamMember(member));
+            }, async error =>
+            {
+                await transaction.RollbackAsync();
+                return BadRequest();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to add member to team {TeamId}", teamId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+
+    [HttpPut]
+    [Route("{memberId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> UpdateTeamMember(
+        [FromRoute] int teamId,
+        [FromRoute] int memberId,
+        [FromBody] TeamMemberUpdateRequest updateRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> updateResult = await teamMemberService.UpdateTeamMemberAsync(
+                memberId,
+                new ITeamMemberService.TeamMemberData(
+                    teamId,
+                    updateRequest.UserId,
+                    updateRequest.IsTeamLeader,
+                    updateRequest.CurrentLatitude,
+                    updateRequest.CurrentLongitude,
+                    updateRequest.LastUpdated
+                ),
+                tracking: true
+            );
+
+            return await updateResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update member {MemberId} in team {TeamId}", memberId, teamId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+
+    [HttpDelete]
+    [Route("{memberId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> DeleteTeamMember(
+        [FromRoute] int teamId,
+        [FromRoute] int memberId)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> deleteResult = await teamMemberService.DeleteTeamMemberAsync(memberId, tracking: true);
+
+            return await deleteResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete member {MemberId} from team {TeamId}", memberId, teamId);
+            await transaction.RollbackAsync();
+            return Problem();
+        }
+    }
+}
+
+public sealed class TeamMemberListResponse
+{
+    public required List<TeamMemberInformationDto> Items { get; init; }
+}
+
+public sealed record TeamMemberInformationDto(int Id, int TeamId, int UserId, bool IsTeamLeader)
+{
+    public static TeamMemberInformationDto FromTeamMember(TeamMember member) =>
+        new(member.Id, member.TeamId, member.UserId, member.IsTeamLeader);
+}
+
+public sealed record TeamMemberDetailsDto(
+    int Id,
+    int TeamId,
+    int UserId,
+    bool IsTeamLeader,
+    double? CurrentLatitude,
+    double? CurrentLongitude,
+    Instant? LastUpdated)
+{
+    public static TeamMemberDetailsDto FromTeamMember(TeamMember member) =>
+        new(member.Id, member.TeamId, member.UserId, member.IsTeamLeader,
+            member.CurrentLatitude, member.CurrentLongitude, member.LastUpdated);
+}
+
+public sealed record TeamMemberAddRequest(
+    int UserId,
+    bool IsTeamLeader = false,
+    double? CurrentLatitude = null,
+    double? CurrentLongitude = null,
+    Instant? LastUpdated = null
+);
+
+public sealed record TeamMemberUpdateRequest(
+    int UserId,
+    bool IsTeamLeader,
+    double? CurrentLatitude,
+    double? CurrentLongitude,
+    Instant? LastUpdated
+);

--- a/backend/XActBackend/Controllers/UserController.cs
+++ b/backend/XActBackend/Controllers/UserController.cs
@@ -1,0 +1,232 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OneOf;
+using OneOf.Types;
+using XActBackend.Core.Services;
+using XActBackend.Persistence.Model;
+using XActBackend.Persistence.Util;
+using XActBackend.Util;
+
+namespace XActBackend.Controllers;
+
+// TODO Review tracking usage
+
+[Route("api/users")]
+public sealed class UserController(
+    ITransactionProvider transaction,
+    IUserService userService,
+    ILogger<UserController> logger) : BaseController
+{
+    [HttpGet]
+    [Route("")]
+    [ProducesResponseType<UserListResponse>(StatusCodes.Status200OK)]
+    public async ValueTask<ActionResult<UserListResponse>> GetAllUsers()
+    {
+        IReadOnlyCollection<User> users = await userService.GetAllUsersAsync(tracking: false);
+
+        return Ok(new UserListResponse
+        {
+            Items = users.Select(UserInformationDto.FromUser).ToList()
+        });
+    }
+
+    [HttpGet]
+    [Route("{userId:int}")]
+    [ProducesResponseType<UserDetailsDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<ActionResult<UserDetailsDto>> GetUserById([FromRoute] int userId)
+    {
+        OneOf<User, NotFound> userResult = await userService.GetUserByIdAsync(userId, tracking: false);
+
+        return userResult.Match<ActionResult<UserDetailsDto>>(
+            user => Ok(UserDetailsDto.FromUser(user)),
+            notFound => NotFound()
+        );
+    }
+
+    [HttpPost]
+    [Route("")]
+    [ProducesResponseType<UserDetailsDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async ValueTask<IActionResult> AddUser([FromBody] UserAddRequest addRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<User, Error> addResult = await userService.AddUserAsync(
+                new IUserService.UserData(
+                    addRequest.Username,
+                    addRequest.Email,
+                    addRequest.PasswordHash,
+                    addRequest.AccountType,
+                    addRequest.SubscriptionEndDate,
+                    addRequest.TotalWins,
+                    addRequest.TotalGamesPlayed
+                )
+            );
+
+            return await addResult.Match<ValueTask<IActionResult>>(async user =>
+            {
+                await transaction.CommitAsync();
+
+                return CreatedAtAction(nameof(GetUserById), new { userId = user.Id },
+                    UserDetailsDto.FromUser(user));
+            }, async error =>
+            {
+                await transaction.RollbackAsync();
+
+                return BadRequest();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to add user");
+            await transaction.RollbackAsync();
+
+            return Problem();
+        }
+    }
+
+    [HttpPut]
+    [Route("{userId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> UpdateUser(
+        [FromRoute] int userId,
+        [FromBody] UserUpdateRequest updateRequest)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> updateResult = await userService.UpdateUserAsync(
+                userId,
+                new IUserService.UserData(
+                    updateRequest.Username,
+                    updateRequest.Email,
+                    updateRequest.PasswordHash,
+                    updateRequest.AccountType,
+                    updateRequest.SubscriptionEndDate,
+                    updateRequest.TotalWins,
+                    updateRequest.TotalGamesPlayed
+                ),
+                tracking: true
+            );
+
+            return await updateResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update user {UserId}", userId);
+            await transaction.RollbackAsync();
+
+            return Problem();
+        }
+    }
+
+    [HttpDelete]
+    [Route("{userId:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async ValueTask<IActionResult> DeleteUser([FromRoute] int userId)
+    {
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<Success, NotFound> deleteResult = await userService.DeleteUserAsync(userId, tracking: true);
+
+            return await deleteResult.Match<ValueTask<IActionResult>>(async success =>
+            {
+                await transaction.CommitAsync();
+
+                return NoContent();
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+
+                return NotFound();
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete user {UserId}", userId);
+            await transaction.RollbackAsync();
+
+            return Problem();
+        }
+    }
+}
+
+public sealed class UserListResponse
+{
+    public required List<UserInformationDto> Items { get; init; }
+}
+
+public sealed record UserInformationDto(
+    int Id,
+    string Username,
+    string Email,
+    AccountType AccountType
+)
+{
+    public static UserInformationDto FromUser(User user) =>
+        new(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.AccountType
+        );
+}
+
+public sealed record UserDetailsDto(
+    int Id,
+    string Username,
+    string Email,
+    AccountType AccountType,
+    Instant? SubscriptionEndDate,
+    int TotalWins,
+    int TotalGamesPlayed
+)
+{
+    public static UserDetailsDto FromUser(User user) =>
+        new(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.AccountType,
+            user.SubscriptionEndDate,
+            user.TotalWins,
+            user.TotalGamesPlayed
+        );
+}
+
+public sealed record UserAddRequest(
+    string Username,
+    string Email,
+    string PasswordHash,
+    AccountType AccountType = AccountType.Free,
+    Instant? SubscriptionEndDate = null,
+    int TotalWins = 0,
+    int TotalGamesPlayed = 0
+);
+
+public sealed record UserUpdateRequest(
+    string Username,
+    string Email,
+    string PasswordHash,
+    AccountType AccountType,
+    Instant? SubscriptionEndDate,
+    int TotalWins,
+    int TotalGamesPlayed
+);


### PR DESCRIPTION
This pull request implements User, Team, and TeamMember services for the X-ACT backend refactoring.

It introduces three new domain services (UserService, TeamService, TeamMemberService) with full CRUD operations using the repository pattern and OneOf for result handling. These services are registered in the dependency injection container and exposed via new API controllers.

Additionally, the GameSessionService was refactored to simplify session creation logic by delegating ID generation to the repository layer.