### PR TITLE
Refactor lobby terminology to game terminology

### DIFF
--- a/xact_frontend/lib/screens/lobby/create_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/create_lobby.dart
@@ -7,14 +7,14 @@ import 'package:xact_frontend/services/app_session.dart';
 import 'package:xact_frontend/services/geofence_store.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
-class CreateLobbyScreen extends StatefulWidget {
-  const CreateLobbyScreen({super.key});
+class CreateGameScreen extends StatefulWidget {
+  const CreateGameScreen({super.key});
 
   @override
-  State<CreateLobbyScreen> createState() => _CreateLobbyScreenState();
+  State<CreateGameScreen> createState() => _CreateGameScreenState();
 }
 
-class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
+class _CreateGameScreenState extends State<CreateGameScreen> {
   final _gameNameController = TextEditingController();
   bool _creating = false;
 
@@ -99,9 +99,9 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => TeamLobbyScreen(
+          builder: (context) => GameLobbyScreen(
             sessionId: sessionId,
-            lobbyCode: session.joinCode,
+            gameCode: session.joinCode,
             gameName: session.sessionName,
             isLeader: true,
           ),

--- a/xact_frontend/lib/screens/lobby/create_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/create_lobby.dart
@@ -15,21 +15,21 @@ class CreateLobbyScreen extends StatefulWidget {
 }
 
 class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
-  final _lobbyNameController = TextEditingController();
+  final _gameNameController = TextEditingController();
   bool _creating = false;
 
   @override
   void dispose() {
-    _lobbyNameController.dispose();
+    _gameNameController.dispose();
     super.dispose();
   }
 
   void _onCreate() async {
-    final lobbyName = _lobbyNameController.text.trim();
+    final gameName = _gameNameController.text.trim();
 
-    if (lobbyName.isEmpty) {
+    if (gameName.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please enter a lobby name')),
+        const SnackBar(content: Text('Please enter a game name')),
       );
       return;
     }
@@ -42,7 +42,7 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
       );
 
       final session = await ApiService.instance.createLobby(
-        lobbyName: lobbyName,
+        lobbyName: gameName,
       );
       final sessionId = session.sessionId;
 
@@ -71,7 +71,7 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Lobby created! Join code: ${session.joinCode}'),
+          content: Text('Game created! Share code: ${session.joinCode}'),
         ),
       );
 
@@ -79,7 +79,10 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
       final areaSaved = await Navigator.push<bool>(
         context,
         MaterialPageRoute(
-          builder: (_) => DefineGameAreaScreen(sessionId: sessionId),
+          builder: (_) => DefineGameAreaScreen(
+            sessionId: sessionId,
+            gameName: session.sessionName,
+          ),
         ),
       );
 
@@ -99,6 +102,7 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
           builder: (context) => TeamLobbyScreen(
             sessionId: sessionId,
             lobbyCode: session.joinCode,
+            gameName: session.sessionName,
             isLeader: true,
           ),
         ),
@@ -107,7 +111,7 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Could not create lobby: $error')));
+      ).showSnackBar(SnackBar(content: Text('Could not create game: $error')));
     } finally {
       if (mounted) {
         setState(() => _creating = false);
@@ -149,7 +153,7 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Create New Lobby',
+            'Create New Game',
             style: TextStyle(
               color: Colors.white,
               fontSize: 24,
@@ -158,16 +162,16 @@ class _CreateLobbyScreenState extends State<CreateLobbyScreen> {
           ),
           const SizedBox(height: 20),
           XActBranding.buildTextField(
-            label: 'Lobby Name',
-            hintText: 'Enter lobby name...',
-            controller: _lobbyNameController,
+            label: 'Game Name',
+            hintText: 'Enter game name...',
+            controller: _gameNameController,
           ),
           const SizedBox(height: 24),
           Row(
             children: [
               Expanded(
                 child: XActBranding.buildSecondaryButton(
-                  text: _creating ? 'Creating...' : 'Create',
+                  text: _creating ? 'Creating game...' : 'Create',
                   onPressed: _creating ? null : _onCreate,
                 ),
               ),

--- a/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
+++ b/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
@@ -8,8 +8,13 @@ import '../../widgets/lobby/define_game_area_widgets.dart';
 
 class DefineGameAreaScreen extends StatefulWidget {
   final int sessionId;
+  final String gameName;
 
-  const DefineGameAreaScreen({super.key, required this.sessionId});
+  const DefineGameAreaScreen({
+    super.key,
+    required this.sessionId,
+    required this.gameName,
+  });
 
   @override
   State<DefineGameAreaScreen> createState() => _DefineGameAreaScreenState();
@@ -18,13 +23,13 @@ class DefineGameAreaScreen extends StatefulWidget {
 class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
   final MapController _mapController = MapController();
 
-  // Points the host has placed – these form the polygon.
+  // Corner markers the host has placed - these form the polygon.
   final List<LatLng> _points = [];
 
-  // Index of the currently selected point, -1 when none is selected.
+  // Index of the currently selected corner marker, -1 when none is selected.
   int _selectedIndex = -1;
 
-  // When true, the next map tap repositions the selected point.
+  // When true, the next map tap repositions the selected corner marker.
   bool _isMoveMode = false;
 
   static const LatLng _fallbackCenter = LatLng(48.3069, 14.2858);
@@ -99,7 +104,7 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
           child: ListTile(
             dense: true,
             leading: Icon(Icons.open_with, color: Colors.white),
-            title: Text('Move point', style: TextStyle(color: Colors.white)),
+            title: Text('Move corner', style: TextStyle(color: Colors.white)),
           ),
         ),
         PopupMenuItem<_PointAction>(
@@ -107,7 +112,7 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
           child: ListTile(
             dense: true,
             leading: Icon(Icons.delete_outline, color: Colors.redAccent),
-            title: Text('Delete point', style: TextStyle(color: Colors.white)),
+            title: Text('Delete corner', style: TextStyle(color: Colors.white)),
           ),
         ),
         PopupMenuItem<_PointAction>(
@@ -144,7 +149,7 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
       builder: (ctx) => AlertDialog(
         backgroundColor: const Color(0xFF252A3A),
         title: Text(
-          'Delete point ${index + 1}?',
+          'Delete corner ${index + 1}?',
           style: const TextStyle(color: Colors.white),
         ),
         actions: [
@@ -181,7 +186,7 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
         backgroundColor: const Color(0xFF252A3A),
         title: const Text('Clear area?', style: TextStyle(color: Colors.white)),
         content: const Text(
-          'This will remove all placed points.',
+          'This will remove all placed corners.',
           style: TextStyle(color: Colors.white70),
         ),
         actions: [
@@ -213,7 +218,7 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
     if (_points.length < 3) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Place at least 3 points to define the game area.'),
+          content: Text('Place at least 3 corners to define the game area.'),
           backgroundColor: Colors.orange,
         ),
       );
@@ -229,14 +234,14 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
   String get _statusText {
     if (_points.isEmpty) return 'Tap on the map to place the first corner';
     if (_isMoveMode && _selectedIndex >= 0) {
-      return 'Move mode: tap on map to set point ${_selectedIndex + 1}';
+      return 'Move mode: tap on map to set corner ${_selectedIndex + 1}';
     }
     if (_selectedIndex >= 0) {
-      return 'Point ${_selectedIndex + 1} selected · choose action from menu';
+      return 'Corner ${_selectedIndex + 1} selected · choose action from menu';
     }
-    if (_points.length == 1) return '1 point placed – add at least 2 more';
-    if (_points.length == 2) return '2 points placed – add at least 1 more';
-    return '${_points.length} points – tap point to select · tap map to add';
+    if (_points.length == 1) return '1 corner placed - add at least 2 more';
+    if (_points.length == 2) return '2 corners placed - add at least 1 more';
+    return '${_points.length} corners - tap a corner to select or tap map to add';
   }
 
   @override
@@ -246,12 +251,12 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
       appBar: AppBar(
         backgroundColor: const Color(0xFF0F172A),
         foregroundColor: Colors.white,
-        title: const Text('Define Game Area'),
+        title: Text('Define ${widget.gameName} Game Area'),
         actions: [
           if (_points.isNotEmpty)
             IconButton(
               icon: const Icon(Icons.undo),
-              tooltip: 'Undo last point',
+              tooltip: 'Undo last corner',
               onPressed: _undoLast,
             ),
           if (_points.isNotEmpty)

--- a/xact_frontend/lib/screens/lobby/join_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/join_lobby.dart
@@ -6,14 +6,14 @@ import 'package:xact_frontend/screens/team/team_lobby.dart';
 import 'package:xact_frontend/services/app_session.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
-class JoinLobbyScreen extends StatefulWidget {
-  const JoinLobbyScreen({super.key});
+class JoinGameScreen extends StatefulWidget {
+  const JoinGameScreen({super.key});
 
   @override
-  State<JoinLobbyScreen> createState() => _JoinLobbyScreenState();
+  State<JoinGameScreen> createState() => _JoinGameScreenState();
 }
 
-class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
+class _JoinGameScreenState extends State<JoinGameScreen> {
   final _gameCodeController = TextEditingController();
   final _usernameController = TextEditingController();
   bool _joining = false;
@@ -104,9 +104,9 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => TeamLobbyScreen(
+          builder: (context) => GameLobbyScreen(
             sessionId: session.sessionId,
-            lobbyCode: session.joinCode,
+            gameCode: session.joinCode,
             gameName: session.sessionName,
             isLeader: false,
           ),

--- a/xact_frontend/lib/screens/lobby/join_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/join_lobby.dart
@@ -14,33 +14,33 @@ class JoinLobbyScreen extends StatefulWidget {
 }
 
 class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
-  final _lobbyCodeController = TextEditingController();
+  final _gameCodeController = TextEditingController();
   final _usernameController = TextEditingController();
   bool _joining = false;
 
   @override
   void dispose() {
-    _lobbyCodeController.dispose();
+    _gameCodeController.dispose();
     _usernameController.dispose();
     super.dispose();
   }
 
   void _onJoin() async {
-    final lobbyCode = _lobbyCodeController.text.trim().toUpperCase();
+    final gameCode = _gameCodeController.text.trim().toUpperCase();
     final username = _usernameController.text.trim();
 
-    if (lobbyCode.isEmpty || username.isEmpty) {
+    if (gameCode.isEmpty || username.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Please fill in all fields')),
       );
       return;
     }
 
-    if (!RegExp(r'^[A-Z0-9]{6}$').hasMatch(lobbyCode)) {
+    if (!RegExp(r'^[A-Z0-9]{6}$').hasMatch(gameCode)) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text(
-            'Lobby code must be 6 characters using uppercase letters and numbers',
+            'Game code must be 6 characters using uppercase letters and numbers',
           ),
         ),
       );
@@ -54,7 +54,7 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
       );
       AppSession.instance.setIdentity(userId: userId, username: username);
 
-      final session = await ApiService.instance.joinLobbyByCode(lobbyCode);
+      final session = await ApiService.instance.joinLobbyByCode(gameCode);
       final snapshot = await ApiService.instance.loadLobbySnapshot(
         session.sessionId,
       );
@@ -107,6 +107,7 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
           builder: (context) => TeamLobbyScreen(
             sessionId: session.sessionId,
             lobbyCode: session.joinCode,
+            gameName: session.sessionName,
             isLeader: false,
           ),
         ),
@@ -115,7 +116,7 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Could not join lobby: $error')));
+      ).showSnackBar(SnackBar(content: Text('Could not join game: $error')));
     } finally {
       if (mounted) {
         setState(() => _joining = false);
@@ -157,7 +158,7 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Join Lobby',
+            'Join Friends Game',
             style: TextStyle(
               color: Colors.white,
               fontSize: 24,
@@ -166,9 +167,9 @@ class _JoinLobbyScreenState extends State<JoinLobbyScreen> {
           ),
           const SizedBox(height: 20),
           XActBranding.buildTextField(
-            label: 'Lobby Code',
+            label: 'Game Code',
             hintText: 'Enter 6-character code...',
-            controller: _lobbyCodeController,
+            controller: _gameCodeController,
             keyboardType: TextInputType.text,
             maxLength: 6,
             textCapitalization: TextCapitalization.characters,

--- a/xact_frontend/lib/screens/lobby/join_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/join_lobby.dart
@@ -158,7 +158,7 @@ class _JoinGameScreenState extends State<JoinGameScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'Join Friends Game',
+            'Join Friend\'s Game',
             style: TextStyle(
               color: Colors.white,
               fontSize: 24,

--- a/xact_frontend/lib/screens/start/playnow_screen.dart
+++ b/xact_frontend/lib/screens/start/playnow_screen.dart
@@ -116,7 +116,7 @@ class PlayNowScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: const [
                       Text(
-                        'Join Friends Game',
+                        "Join Friend's Game",
                         style: TextStyle(
                           color: Colors.white,
                           fontSize: 18,

--- a/xact_frontend/lib/screens/start/playnow_screen.dart
+++ b/xact_frontend/lib/screens/start/playnow_screen.dart
@@ -64,7 +64,7 @@ class PlayNowScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: const [
                       Text(
-                        'Start a New Game',
+                        'Start New Game',
                         style: TextStyle(
                           color: Colors.white,
                           fontSize: 18,
@@ -73,7 +73,7 @@ class PlayNowScreen extends StatelessWidget {
                       ),
                       SizedBox(height: 8),
                       Text(
-                        "You'll be the host and get a code to share with your friends so they can join your game room",
+                        'Create a game and open its lobby so friends can join with your game code',
                         style: TextStyle(color: Colors.white70, fontSize: 14),
                       ),
                     ],
@@ -116,7 +116,7 @@ class PlayNowScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: const [
                       Text(
-                        "Join a Friend's Game",
+                        'Join Friends Game',
                         style: TextStyle(
                           color: Colors.white,
                           fontSize: 18,
@@ -125,7 +125,7 @@ class PlayNowScreen extends StatelessWidget {
                       ),
                       SizedBox(height: 8),
                       Text(
-                        'Enter the code your friend shared with you to join their game room',
+                        'Enter a game code to join your friends in the lobby',
                         style: TextStyle(color: Colors.white70, fontSize: 14),
                       ),
                     ],

--- a/xact_frontend/lib/screens/start/playnow_screen.dart
+++ b/xact_frontend/lib/screens/start/playnow_screen.dart
@@ -47,7 +47,7 @@ class PlayNowScreen extends StatelessWidget {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => const CreateLobbyScreen(),
+                builder: (context) => const CreateGameScreen(),
               ),
             );
           },
@@ -100,7 +100,7 @@ class PlayNowScreen extends StatelessWidget {
           onTap: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => const JoinLobbyScreen()),
+              MaterialPageRoute(builder: (context) => const JoinGameScreen()),
             );
           },
           borderRadius: BorderRadius.circular(12),

--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -18,25 +18,25 @@ import 'package:xact_frontend/widgets/team/team_data.dart';
 import 'package:xact_frontend/widgets/team/team_overview_card.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
-class TeamLobbyScreen extends StatefulWidget {
+class GameLobbyScreen extends StatefulWidget {
   final int sessionId;
-  final String lobbyCode;
+  final String gameCode;
   final String gameName;
   final bool isLeader;
 
-  const TeamLobbyScreen({
+  const GameLobbyScreen({
     super.key,
     required this.sessionId,
-    required this.lobbyCode,
+    required this.gameCode,
     required this.gameName,
     required this.isLeader,
   });
 
   @override
-  State<TeamLobbyScreen> createState() => _TeamLobbyScreenState();
+  State<GameLobbyScreen> createState() => _GameLobbyScreenState();
 }
 
-class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
+class _GameLobbyScreenState extends State<GameLobbyScreen> {
   bool _loading = true;
   bool _working = false;
   bool _gameTransitionStarted = false;
@@ -235,8 +235,8 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
     });
   }
 
-  void _copyLobbyCode() {
-    Clipboard.setData(ClipboardData(text: widget.lobbyCode));
+  void _copyGameCode() {
+    Clipboard.setData(ClipboardData(text: widget.gameCode));
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(const SnackBar(content: Text('Game code copied!')));
@@ -513,7 +513,7 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
       body: SafeArea(
         child: Column(
           children: [
-            LobbyHeader(
+            GameLobbyHeader(
               gameName: widget.gameName,
               totalPlayers: _totalPlayers,
               isLeader: leader,
@@ -530,10 +530,10 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
                   ),
                   child: Column(
                     children: [
-                      LobbyCodeCard(
-                        lobbyCode: widget.lobbyCode,
+                      GameCodeCard(
+                        gameCode: widget.gameCode,
                         codeLabel: 'Game Code',
-                        onCopy: _copyLobbyCode,
+                        onCopy: _copyGameCode,
                       ),
                       if (_working) ...[
                         const SizedBox(height: 8),

--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -21,12 +21,14 @@ import 'package:xact_frontend/widgets/xact_branding.dart';
 class TeamLobbyScreen extends StatefulWidget {
   final int sessionId;
   final String lobbyCode;
+  final String gameName;
   final bool isLeader;
 
   const TeamLobbyScreen({
     super.key,
     required this.sessionId,
     required this.lobbyCode,
+    required this.gameName,
     required this.isLeader,
   });
 
@@ -167,7 +169,9 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Failed to load lobby: $error')));
+      ).showSnackBar(
+        SnackBar(content: Text('Failed to load game lobby: $error')),
+      );
     } finally {
       if (mounted && !silent) {
         setState(() => _loading = false);
@@ -235,7 +239,7 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
     Clipboard.setData(ClipboardData(text: widget.lobbyCode));
     ScaffoldMessenger.of(
       context,
-    ).showSnackBar(const SnackBar(content: Text('Lobby code copied!')));
+    ).showSnackBar(const SnackBar(content: Text('Game code copied!')));
   }
 
   Future<void> _addTeam() async {
@@ -510,6 +514,7 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
         child: Column(
           children: [
             LobbyHeader(
+              gameName: widget.gameName,
               totalPlayers: _totalPlayers,
               isLeader: leader,
               onQrPressed: () {},
@@ -527,6 +532,7 @@ class _TeamLobbyScreenState extends State<TeamLobbyScreen> {
                     children: [
                       LobbyCodeCard(
                         lobbyCode: widget.lobbyCode,
+                        codeLabel: 'Game Code',
                         onCopy: _copyLobbyCode,
                       ),
                       if (_working) ...[

--- a/xact_frontend/lib/widgets/lobby/define_game_area_widgets.dart
+++ b/xact_frontend/lib/widgets/lobby/define_game_area_widgets.dart
@@ -262,7 +262,7 @@ class DefineGameAreaBottomPanel extends StatelessWidget {
                 if (pointCount > 0) ...[
                   const SizedBox(height: 4),
                   Text(
-                    '$pointCount ${pointCount == 1 ? 'point' : 'points'} placed',
+                    '$pointCount ${pointCount == 1 ? 'corner' : 'corners'} placed',
                     style: TextStyle(
                       color: Colors.blue.shade300,
                       fontSize: 12,

--- a/xact_frontend/lib/widgets/team/lobby_code_card.dart
+++ b/xact_frontend/lib/widgets/team/lobby_code_card.dart
@@ -32,7 +32,7 @@ class GameCodeCard extends StatelessWidget {
               children: [
                 Text(
                   codeLabel,
-                  style: TextStyle(color: Colors.white54, fontSize: 12),
+                  style: const TextStyle(color: Colors.white54, fontSize: 12),
                 ),
                 const SizedBox(height: 4),
                 Text(

--- a/xact_frontend/lib/widgets/team/lobby_code_card.dart
+++ b/xact_frontend/lib/widgets/team/lobby_code_card.dart
@@ -5,11 +5,13 @@ import '../xact_branding.dart';
 /// Card displaying the lobby code with a copy button.
 class LobbyCodeCard extends StatelessWidget {
   final String lobbyCode;
+  final String codeLabel;
   final VoidCallback onCopy;
 
   const LobbyCodeCard({
     super.key,
     required this.lobbyCode,
+    this.codeLabel = 'Game Code',
     required this.onCopy,
   });
 
@@ -28,8 +30,8 @@ class LobbyCodeCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
-                  'Lobby Code',
+                Text(
+                  codeLabel,
                   style: TextStyle(color: Colors.white54, fontSize: 12),
                 ),
                 const SizedBox(height: 4),

--- a/xact_frontend/lib/widgets/team/lobby_code_card.dart
+++ b/xact_frontend/lib/widgets/team/lobby_code_card.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 import '../xact_branding.dart';
 
 /// Card displaying the lobby code with a copy button.
-class LobbyCodeCard extends StatelessWidget {
-  final String lobbyCode;
+class GameCodeCard extends StatelessWidget {
+  final String gameCode;
   final String codeLabel;
   final VoidCallback onCopy;
 
-  const LobbyCodeCard({
+  const GameCodeCard({
     super.key,
-    required this.lobbyCode,
+    required this.gameCode,
     this.codeLabel = 'Game Code',
     required this.onCopy,
   });
@@ -36,7 +36,7 @@ class LobbyCodeCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  lobbyCode,
+                  gameCode,
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 28,

--- a/xact_frontend/lib/widgets/team/lobby_header.dart
+++ b/xact_frontend/lib/widgets/team/lobby_header.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 
 /// Header row for the game lobby showing title, player count and QR button.
 class LobbyHeader extends StatelessWidget {
+  final String gameName;
   final int totalPlayers;
   final bool isLeader;
   final VoidCallback? onQrPressed;
 
   const LobbyHeader({
     super.key,
+    required this.gameName,
     required this.totalPlayers,
     required this.isLeader,
     this.onQrPressed,
@@ -23,8 +25,8 @@ class LobbyHeader extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
-                  'Game Lobby',
+                Text(
+                  gameName,
                   style: TextStyle(
                     color: Colors.white,
                     fontSize: 22,
@@ -33,8 +35,8 @@ class LobbyHeader extends StatelessWidget {
                 ),
                 const SizedBox(height: 2),
                 Text(
-                  '$totalPlayers players in lobby'
-                  '${isLeader ? '  •  Lobby Leader' : ''}',
+                  '$totalPlayers players in game lobby'
+                  '${isLeader ? '  •  Game Host' : ''}',
                   style: const TextStyle(color: Colors.white60, fontSize: 13),
                 ),
               ],

--- a/xact_frontend/lib/widgets/team/lobby_header.dart
+++ b/xact_frontend/lib/widgets/team/lobby_header.dart
@@ -27,7 +27,7 @@ class GameLobbyHeader extends StatelessWidget {
               children: [
                 Text(
                   gameName,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: Colors.white,
                     fontSize: 22,
                     fontWeight: FontWeight.bold,

--- a/xact_frontend/lib/widgets/team/lobby_header.dart
+++ b/xact_frontend/lib/widgets/team/lobby_header.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 /// Header row for the game lobby showing title, player count and QR button.
-class LobbyHeader extends StatelessWidget {
+class GameLobbyHeader extends StatelessWidget {
   final String gameName;
   final int totalPlayers;
   final bool isLeader;
   final VoidCallback? onQrPressed;
 
-  const LobbyHeader({
+  const GameLobbyHeader({
     super.key,
     required this.gameName,
     required this.totalPlayers,

--- a/xact_frontend/pubspec.lock
+++ b/xact_frontend/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -244,10 +244,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   http:
     dependency: "direct main"
     description:
@@ -340,18 +340,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   message_pack_dart:
     dependency: transitive
     description:
@@ -528,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   shelf:
     dependency: transitive
     description:
@@ -569,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: sse
-      sha256: fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643
+      sha256: a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.8"
+    version: "4.2.0"
   sse_channel:
     dependency: transitive
     description:
@@ -617,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   tuple:
     dependency: transitive
     description:
@@ -734,5 +742,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.4"


### PR DESCRIPTION
Update naming conventions and text across multiple screens and components for consistency, replacing "lobby" with "game." This enhances clarity and aligns with the overall theme of the application.