### PR TITLE
Make game area location dynamic based on device GPS

### DIFF
--- a/xact_frontend/lib/constants.dart
+++ b/xact_frontend/lib/constants.dart
@@ -1,0 +1,4 @@
+import 'package:latlong2/latlong.dart';
+
+/// Fallback map center used when neither a geofence nor a GPS fix is available.
+const LatLng kFallbackMapCenter = LatLng(48.3069, 14.2858);

--- a/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
+++ b/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../constants.dart';
 import '../../services/geofence_store.dart';
 import '../../services/location_service.dart';
 import '../../widgets/lobby/define_game_area_widgets.dart';
@@ -32,8 +33,8 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
   // When true, the next map tap repositions the selected corner marker.
   bool _isMoveMode = false;
 
-  // Hardcoded fallback used only when GPS is unavailable / denied (HTL Leonding).
-  static const LatLng _fallbackCenter = LatLng(48.3069, 14.2858);
+  // Fallback used only when GPS is unavailable / denied.
+  static const LatLng _fallbackCenter = kFallbackMapCenter;
 
   // Resolved initial center – null while GPS is being acquired.
   LatLng? _initialCenter;

--- a/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
+++ b/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
@@ -32,24 +32,62 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
   // When true, the next map tap repositions the selected corner marker.
   bool _isMoveMode = false;
 
+  // Hardcoded fallback used only when GPS is unavailable / denied (HTL Leonding).
   static const LatLng _fallbackCenter = LatLng(48.3069, 14.2858);
+
+  // Resolved initial center – null while GPS is being acquired.
+  LatLng? _initialCenter;
+
+  // True while waiting for the first GPS fix on screen open.
+  bool _isLocating = true;
+
+  // True when permission was denied and we had to fall back to [_fallbackCenter].
+  bool _usedFallback = false;
 
   @override
   void initState() {
     super.initState();
-    _centerOnPlayer();
+    _resolveInitialCenter();
   }
 
-  /// Centers the map on the player's GPS position if available.
-  void _centerOnPlayer() {
-    final pos = LocationService.instance.lastKnownPosition;
-    if (pos != null) {
-      // Schedule after the first frame so the MapController is ready.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _mapController.move(LatLng(pos.latitude, pos.longitude), 15.0);
-        }
+  /// Tries to resolve the map's initial center from the device GPS.
+  /// Falls back to [_fallbackCenter] when permission is denied, location
+  /// services are disabled, or the lookup times out.
+  Future<void> _resolveInitialCenter() async {
+    final cached = LocationService.instance.lastKnownPosition;
+    if (cached != null) {
+      if (!mounted) return;
+      setState(() {
+        _initialCenter = LatLng(cached.latitude, cached.longitude);
+        _isLocating = false;
       });
+      return;
+    }
+
+    final position = await LocationService.instance.getCurrentPosition();
+    if (!mounted) return;
+
+    if (position != null) {
+      setState(() {
+        _initialCenter = LatLng(position.latitude, position.longitude);
+        _isLocating = false;
+      });
+    } else {
+      setState(() {
+        _initialCenter = _fallbackCenter;
+        _isLocating = false;
+        _usedFallback = true;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Could not detect your location – using default area. '
+            'Enable location permission to center the map on you.',
+          ),
+          backgroundColor: Colors.orange,
+          duration: Duration(seconds: 4),
+        ),
+      );
     }
   }
 
@@ -267,37 +305,94 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
             ),
         ],
       ),
-      body: Stack(
+      body: _isLocating ? _buildLocatingView() : _buildMapView(),
+    );
+  }
+
+  Widget _buildLocatingView() {
+    return const Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          DefineGameAreaMap(
-            mapController: _mapController,
-            fallbackCenter: _fallbackCenter,
-            points: _points,
-            selectedIndex: _selectedIndex,
-            isMoveMode: _isMoveMode,
-            onMapTap: _onMapTap,
-            onPointTapDown: (index) =>
-                (details) => _showPointMenu(index, details.globalPosition),
-          ),
-
-          // ── Crosshair hint overlay ──────────────────────────────
-          const Center(child: DefineGameAreaCrosshairOverlay()),
-
-          // ── Status bar at bottom ────────────────────────────────
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: DefineGameAreaBottomPanel(
-              statusText: _statusText,
-              pointCount: _points.length,
-              isSaving: false,
-              canSave: _points.length >= 3,
-              onSave: _save,
-            ),
+          CircularProgressIndicator(color: Colors.blue),
+          SizedBox(height: 16),
+          Text(
+            'Detecting your location…',
+            style: TextStyle(color: Colors.white70, fontSize: 14),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildMapView() {
+    return Stack(
+      children: [
+        DefineGameAreaMap(
+          mapController: _mapController,
+          fallbackCenter: _initialCenter ?? _fallbackCenter,
+          points: _points,
+          selectedIndex: _selectedIndex,
+          isMoveMode: _isMoveMode,
+          onMapTap: _onMapTap,
+          onPointTapDown: (index) =>
+              (details) => _showPointMenu(index, details.globalPosition),
+        ),
+
+        // ── Crosshair hint overlay ──────────────────────────────
+        const Center(child: DefineGameAreaCrosshairOverlay()),
+
+        // ── Fallback notice when GPS was unavailable ────────────
+        if (_usedFallback)
+          Positioned(
+            top: 8,
+            left: 12,
+            right: 12,
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.orange.shade800.withValues(alpha: 0.92),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Row(
+                  children: [
+                    Icon(
+                      Icons.location_off,
+                      color: Colors.white,
+                      size: 18,
+                    ),
+                    SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Using default location – enable GPS to center on you.',
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+        // ── Status bar at bottom ────────────────────────────────
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: DefineGameAreaBottomPanel(
+            statusText: _statusText,
+            pointCount: _points.length,
+            isSaving: false,
+            canSave: _points.length >= 3,
+            onSave: _save,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/xact_frontend/lib/services/location_service.dart
+++ b/xact_frontend/lib/services/location_service.dart
@@ -67,6 +67,42 @@ final class LocationService {
         permission == LocationPermission.always;
   }
 
+  /// Returns a one-shot GPS fix, or `null` when permissions are denied,
+  /// location services are off, or the lookup fails / times out.
+  ///
+  /// Callers should treat `null` as "use a fallback location" – this method
+  /// never throws.
+  Future<Position?> getCurrentPosition({
+    Duration timeLimit = const Duration(seconds: 10),
+  }) async {
+    try {
+      final granted = await requestPermission();
+      if (!granted) return null;
+
+      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        return await Geolocator.getLastKnownPosition();
+      }
+
+      final position = await Geolocator.getCurrentPosition(
+        locationSettings: LocationSettings(
+          accuracy: LocationAccuracy.high,
+          timeLimit: timeLimit,
+        ),
+      );
+      lastKnownPosition = position;
+      _positionController.add(position);
+      return position;
+    } catch (_) {
+      // Timeout or platform error – fall back to last known fix if we have one.
+      try {
+        return await Geolocator.getLastKnownPosition();
+      } catch (_) {
+        return null;
+      }
+    }
+  }
+
   /// Starts watching the device position and feeding [positionStream] without
   /// uploading anything to the backend. Use this when you just need the map to
   /// show the player's real position (e.g. before the game starts / no login

--- a/xact_frontend/lib/widgets/map_area.dart
+++ b/xact_frontend/lib/widgets/map_area.dart
@@ -6,6 +6,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import '../api/api_service.dart';
 import '../api/models.dart';
+import '../constants.dart';
 import '../services/app_session.dart';
 import '../services/geofence_store.dart';
 import '../services/location_service.dart';
@@ -29,14 +30,20 @@ class MapArea extends StatefulWidget {
 class _MapAreaState extends State<MapArea> {
   final MapController _mapController = MapController();
 
-  // Fallback center (HTL Leonding) – overridden as soon as GPS kicks in.
-  static const LatLng _fallbackCenter = LatLng(48.3069, 14.2858);
+  // Fallback used only when neither a geofence nor a GPS fix is available.
+  static const LatLng _fallbackCenter = kFallbackMapCenter;
 
   // Current GPS position of "this" player. Null until first fix.
   LatLng? _myPosition;
 
   // When true, the map auto-pans to follow the player's GPS position.
-  bool _followMode = true;
+  // Defaults to true when no geofence is available; defaults to false when
+  // we have an area to display (the area should stay framed unless the user
+  // explicitly recenters on themselves).
+  late bool _followMode;
+
+  // Initial camera center, resolved synchronously in initState.
+  late LatLng _initialMapCenter;
 
   // When true, the control buttons are expanded (burger menu open).
   bool _showControls = false;
@@ -55,10 +62,51 @@ class _MapAreaState extends State<MapArea> {
   @override
   void initState() {
     super.initState();
+
+    // Use the cached geofence (set by the host on save, or by a prior load)
+    // so the very first frame is already framed on the game area.
+    final cachedGeofence = GeofenceStore.instance.points;
+    if (cachedGeofence.length >= 3) {
+      _geofencePoints = List.of(cachedGeofence);
+      _initialMapCenter = LatLngBounds.fromPoints(_geofencePoints).center;
+      _followMode = false;
+    } else {
+      final lastFix = LocationService.instance.lastKnownPosition;
+      _initialMapCenter = lastFix != null
+          ? LatLng(lastFix.latitude, lastFix.longitude)
+          : _fallbackCenter;
+      _followMode = true;
+    }
+
     _startListeningToGps();
     _loadSessionGeofence();
     _refreshPlayers();
     _listenToRealtimeUpdates();
+
+    // If we already have a geofence, fit the camera tightly on the next frame
+    // (initialCenter alone doesn't pick the right zoom for the polygon).
+    if (_geofencePoints.length >= 3) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _fitCameraToGeofence();
+      });
+    }
+  }
+
+  /// Fits the camera so the entire geofence polygon is visible with padding.
+  /// No-op when fewer than 3 points are available.
+  void _fitCameraToGeofence() {
+    if (!mounted || _geofencePoints.length < 3) return;
+    try {
+      _mapController.fitCamera(
+        CameraFit.bounds(
+          bounds: LatLngBounds.fromPoints(_geofencePoints),
+          padding: const EdgeInsets.all(40),
+          maxZoom: 17.0,
+        ),
+      );
+    } catch (_) {
+      // Map controller not yet attached – ignore; the next load will retry.
+    }
   }
 
   @override
@@ -98,15 +146,31 @@ class _MapAreaState extends State<MapArea> {
       return;
     }
 
+    final hadGeofenceBefore = _geofencePoints.length >= 3;
+
     try {
       final points = await ApiService.instance.loadGeofencePoints(sessionId);
       if (!mounted) return;
+      final loaded = points
+              ?.map((p) => LatLng(p.latitude, p.longitude))
+              .toList(growable: false) ??
+          const <LatLng>[];
       setState(() {
-        _geofencePoints = points
-                ?.map((p) => LatLng(p.latitude, p.longitude))
-                .toList(growable: false) ??
-            [];
+        _geofencePoints = loaded;
       });
+      if (loaded.length >= 3) {
+        // Cache so the next MapArea (e.g. after fullscreen toggle) starts
+        // already framed on the area without a backend round-trip.
+        GeofenceStore.instance.setPoints(loaded);
+        // Only auto-fit when this load actually introduced the polygon –
+        // refreshing in-place shouldn't yank the camera away from the user.
+        if (!hadGeofenceBefore) {
+          setState(() => _followMode = false);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _fitCameraToGeofence();
+          });
+        }
+      }
     } catch (_) {
       if (!mounted) return;
       final cached = GeofenceStore.instance.points;
@@ -225,8 +289,6 @@ class _MapAreaState extends State<MapArea> {
 
   @override
   Widget build(BuildContext context) {
-    final center = _myPosition ?? _fallbackCenter;
-
     return Container(
       decoration: BoxDecoration(
         color: const Color(0xFF1E293B),
@@ -239,7 +301,7 @@ class _MapAreaState extends State<MapArea> {
           FlutterMap(
             mapController: _mapController,
             options: MapOptions(
-              initialCenter: center,
+              initialCenter: _initialMapCenter,
               initialZoom: 15.0,
               minZoom: 10.0,
               maxZoom: 18.0,


### PR DESCRIPTION
Enable the game area to use the device's GPS location by default, falling back to a hardcoded location only when necessary. Refactor the map behavior to prioritize the defined game area for focus and display.