### PR TITLE
feat: update team and role display naming in UI components

### DIFF
--- a/xact_frontend/lib/api/api_service_data.dart
+++ b/xact_frontend/lib/api/api_service_data.dart
@@ -23,7 +23,7 @@ extension ApiServiceDataMethods on ApiService {
               .toList(growable: false);
 
           return TeamCardData(
-            teamName: team.teamName,
+            teamName: formatTeamNameWithRole(team.teamName, team.role),
             color: color,
             isMisterX: team.role == TeamRole.mrX,
             members: members,
@@ -48,7 +48,7 @@ extension ApiServiceDataMethods on ApiService {
         (snapshot.membersByTeamId[team.teamId] ?? const []).length;
 
     return TeamChatHeaderData(
-      teamName: team.teamName,
+      teamName: formatTeamNameWithRole(team.teamName, team.role),
       memberCount: memberCount,
       teamColor: tryParseHexColor(team.colorCode) ?? Colors.blue,
     );
@@ -61,7 +61,8 @@ extension ApiServiceDataMethods on ApiService {
     }
 
     final details = await _getGameSession(sessionId);
-    if (details.revealIntervalSeconds <= 0 || details.revealSecondsRemaining <= 0) {
+    if (details.revealIntervalSeconds <= 0 ||
+        details.revealSecondsRemaining <= 0) {
       return const MapHeaderData(nextPingText: 'Next ping: -');
     }
 

--- a/xact_frontend/lib/api/models.dart
+++ b/xact_frontend/lib/api/models.dart
@@ -104,6 +104,23 @@ TeamRole? tryParseTeamRole(String value) {
   };
 }
 
+String teamRoleDisplayLabel(TeamRole? role) {
+  return switch (role) {
+    TeamRole.mrX => 'MixterX',
+    TeamRole.detective => 'Detective',
+    TeamRole.spectator => 'Spectator',
+    null => 'Unknown',
+  };
+}
+
+String formatTeamNameWithRole(String teamName, TeamRole? role) {
+  if (role == null) {
+    return teamName;
+  }
+
+  return '$teamName (${teamRoleDisplayLabel(role)})';
+}
+
 AccountType? tryParseAccountType(String value) {
   return switch (value) {
     'FREE' => AccountType.free,
@@ -278,7 +295,8 @@ final class GameSessionDetails {
       endTime: tryParseIsoDateTime(json['endTime']),
       plannedDurationMinutes: (json['plannedDurationMinutes'] as num).toInt(),
       mrXRevealInterval: (json['mrXRevealInterval'] as num).toInt(),
-      serverNow: tryParseIsoDateTime(json['serverNow']) ?? DateTime.now().toUtc(),
+      serverNow:
+          tryParseIsoDateTime(json['serverNow']) ?? DateTime.now().toUtc(),
       nextRevealAt: tryParseIsoDateTime(json['nextRevealAt']),
       revealSecondsRemaining: _readInt(json, ['revealSecondsRemaining']),
       revealIntervalSeconds: _readInt(json, ['revealIntervalSeconds']),
@@ -655,20 +673,26 @@ final class GameSessionSnapshot {
       endTime: tryParseIsoDateTime(json['endTime']),
       plannedDurationMinutes: _readInt(json, ['plannedDurationMinutes']),
       mrXRevealInterval: _readInt(json, ['mrXRevealInterval']),
-      teams: (json['teams'] as List?)
+      teams:
+          (json['teams'] as List?)
               ?.whereType<Map>()
               .map((e) => SnapshotTeam.fromJson(e.cast<String, dynamic>()))
               .toList(growable: false) ??
           const [],
-      members: (json['members'] as List?)
-              ?.whereType<Map>()
-              .map((e) => SnapshotTeamMember.fromJson(e.cast<String, dynamic>()))
-              .toList(growable: false) ??
-          const [],
-      latestLocations: (json['latestLocations'] as List?)
+      members:
+          (json['members'] as List?)
               ?.whereType<Map>()
               .map(
-                (e) => SnapshotLatestLocation.fromJson(e.cast<String, dynamic>()),
+                (e) => SnapshotTeamMember.fromJson(e.cast<String, dynamic>()),
+              )
+              .toList(growable: false) ??
+          const [],
+      latestLocations:
+          (json['latestLocations'] as List?)
+              ?.whereType<Map>()
+              .map(
+                (e) =>
+                    SnapshotLatestLocation.fromJson(e.cast<String, dynamic>()),
               )
               .toList(growable: false) ??
           const [],

--- a/xact_frontend/lib/api/models.dart
+++ b/xact_frontend/lib/api/models.dart
@@ -114,7 +114,7 @@ String teamRoleDisplayLabel(TeamRole? role) {
 }
 
 String formatTeamNameWithRole(String teamName, TeamRole? role) {
-  if (role == null) {
+  if (role == null || role == TeamRole.spectator) {
     return teamName;
   }
 

--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -118,7 +118,8 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
                 teamId: team.teamId,
                 userId: m.userId,
                 name: displayName,
-                isCurrentUser: currentUserId != null && m.userId == currentUserId,
+                isCurrentUser:
+                    currentUserId != null && m.userId == currentUserId,
                 isTeamLeader: m.isTeamLeader,
               );
             })
@@ -143,7 +144,9 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
         );
       }
 
-      final currentTeamIds = teams.map((team) => team.teamId).toSet();
+      final orderedTeams = _sortTeamsByTeamId(teams);
+
+      final currentTeamIds = orderedTeams.map((team) => team.teamId).toSet();
       _teamUiConfigById.removeWhere(
         (teamId, _) => !currentTeamIds.contains(teamId),
       );
@@ -157,20 +160,17 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
 
         try {
           await ApiService.instance.registerCurrentMemberPresence();
-        } catch (_) {
-        }
+        } catch (_) {}
       }
 
       setState(() {
-        _teams = teams;
+        _teams = orderedTeams;
         _spectators = spectators;
         _spectatorTeamId = spectatorTeamId;
       });
     } catch (error) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to load game lobby: $error')),
       );
     } finally {
@@ -178,6 +178,11 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
         setState(() => _loading = false);
       }
     }
+  }
+
+  List<TeamData> _sortTeamsByTeamId(List<TeamData> incomingTeams) {
+    incomingTeams.sort((a, b) => a.teamId.compareTo(b.teamId));
+    return incomingTeams;
   }
 
   Future<void> _initRealtime() async {
@@ -428,7 +433,9 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
   }
 
   void _randomizeTeams() {
-    final misterXTeams = _teams.where((team) => team.isMisterX).toList(growable: false);
+    final misterXTeams = _teams
+        .where((team) => team.isMisterX)
+        .toList(growable: false);
     final detectiveTeams = _teams
         .where((team) => !team.isMisterX && !team.isSpectator)
         .toList(growable: false);
@@ -436,7 +443,9 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
     if (misterXTeams.isEmpty || detectiveTeams.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Randomize requires one Mister X and one detective team.'),
+          content: Text(
+            'Randomize requires one Mister X and one detective team.',
+          ),
         ),
       );
       return;
@@ -444,8 +453,10 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
 
     final misterXTeam = misterXTeams.first;
 
-    final players = [..._spectators, ..._teams.expand((team) => team.players)]
-        .toList(growable: true);
+    final players = [
+      ..._spectators,
+      ..._teams.expand((team) => team.players),
+    ].toList(growable: true);
 
     if (players.length < 2) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -459,7 +470,9 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
     final moves = <_PlannedMove>[];
 
     final mrXPlayer = players.removeAt(0);
-    moves.add(_PlannedMove(player: mrXPlayer, targetTeamId: misterXTeam.teamId));
+    moves.add(
+      _PlannedMove(player: mrXPlayer, targetTeamId: misterXTeam.teamId),
+    );
 
     for (var i = 0; i < players.length; i++) {
       final targetTeam = detectiveTeams[i % detectiveTeams.length];

--- a/xact_frontend/lib/screens/team_screen.dart
+++ b/xact_frontend/lib/screens/team_screen.dart
@@ -67,7 +67,11 @@ class _TeamScreenState extends State<TeamScreen> {
             );
           }
 
-          if (teams.isEmpty) {
+          final visibleTeams = teams
+              .where((team) => team.members.isNotEmpty)
+              .toList(growable: false);
+
+          if (visibleTeams.isEmpty) {
             return const Center(
               child: Padding(
                 padding: EdgeInsets.all(24),
@@ -81,10 +85,10 @@ class _TeamScreenState extends State<TeamScreen> {
 
           return ListView.separated(
             padding: const EdgeInsets.all(16),
-            itemCount: teams.length,
+            itemCount: visibleTeams.length,
             separatorBuilder: (context, index) => const SizedBox(height: 12),
             itemBuilder: (context, index) {
-              final team = teams[index];
+              final team = visibleTeams[index];
               return TeamCard(
                 teamName: team.teamName,
                 color: team.color,

--- a/xact_frontend/lib/widgets/team/lobby_team_card.dart
+++ b/xact_frontend/lib/widgets/team/lobby_team_card.dart
@@ -52,7 +52,7 @@ class LobbyTeamCard extends StatelessWidget {
                 children: [
                   Expanded(
                     child: Text(
-                      team.name,
+                      team.displayName,
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 16,

--- a/xact_frontend/lib/widgets/team/spectators_card.dart
+++ b/xact_frontend/lib/widgets/team/spectators_card.dart
@@ -53,8 +53,6 @@ class SpectatorsCard extends StatelessWidget {
                   ),
                   const SizedBox(width: 8),
                   const Icon(Icons.visibility, color: Colors.white38, size: 18),
-                  const SizedBox(width: 6),
-                  const Icon(Icons.edit, color: Colors.white38, size: 18),
                   const Spacer(),
                   Text(
                     '${spectators.length}/∞',

--- a/xact_frontend/lib/widgets/team/team_data.dart
+++ b/xact_frontend/lib/widgets/team/team_data.dart
@@ -43,4 +43,5 @@ class TeamData {
 
   bool get isMisterX => role == TeamRole.mrX;
   bool get isSpectator => role == TeamRole.spectator;
+  String get displayName => formatTeamNameWithRole(name, role);
 }

--- a/xact_frontend/lib/widgets/team/team_overview_card.dart
+++ b/xact_frontend/lib/widgets/team/team_overview_card.dart
@@ -48,7 +48,7 @@ class TeamOverviewCard extends StatelessWidget {
               _overviewChip('Spectators', Colors.grey, '$spectatorCount/∞'),
               ...teams.map(
                 (t) => _overviewChip(
-                  t.name,
+                  t.displayName,
                   t.color,
                   '${t.players.length}/${t.maxPlayers}',
                 ),

--- a/xact_frontend/pubspec.lock
+++ b/xact_frontend/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -348,18 +348,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   message_pack_dart:
     dependency: transitive
     description:
@@ -633,10 +633,10 @@ packages:
     dependency: transitive
     description:
       name: sse
-      sha256: a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302
+      sha256: fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.1.8"
   sse_channel:
     dependency: transitive
     description:
@@ -681,10 +681,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   tuple:
     dependency: transitive
     description:
@@ -830,5 +830,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"


### PR DESCRIPTION
Team names are now displayed consistently in the UI as “Team Name (Role)” (for example, “MixterX” or “Detective”). Team cards also keep a stable order after edits by sorting by teamId,.