### PR TITLE
fix: restart countdown when it reaches 0

### DIFF
--- a/xact_frontend/lib/api/api_service_data.dart
+++ b/xact_frontend/lib/api/api_service_data.dart
@@ -63,15 +63,15 @@ extension ApiServiceDataMethods on ApiService {
     }
 
     final details = await _getGameSession(sessionId);
-    if (details.revealIntervalSeconds <= 0 ||
-        details.revealSecondsRemaining <= 0) {
+    if (details.revealIntervalSeconds <= 0) {
       return const MapHeaderData(nextPingText: 'Next ping: -');
     }
 
-    final display = _formatDuration(details.revealSecondsRemaining);
+    final remainingSeconds = _resolveRemainingRevealSeconds(details);
+    final display = _formatDuration(remainingSeconds);
     return MapHeaderData(
       nextPingText: 'Next ping: $display',
-      remainingSeconds: details.revealSecondsRemaining,
+      remainingSeconds: remainingSeconds,
       intervalSeconds: details.revealIntervalSeconds,
     );
   }
@@ -193,4 +193,18 @@ String _formatDuration(int totalSeconds) {
   return seconds == 0
       ? '${minutes}m'
       : '${minutes}m ${seconds.toString().padLeft(2, '0')}s';
+}
+
+int _resolveRemainingRevealSeconds(GameSessionDetails details) {
+  final nextRevealAt = details.nextRevealAt;
+  final serverNow = details.serverNow;
+
+  if (nextRevealAt != null) {
+    final computedSeconds = nextRevealAt.difference(serverNow).inSeconds;
+    if (computedSeconds > 0) {
+      return computedSeconds;
+    }
+  }
+
+  return details.revealSecondsRemaining;
 }

--- a/xact_frontend/lib/widgets/map_header.dart
+++ b/xact_frontend/lib/widgets/map_header.dart
@@ -44,6 +44,15 @@ class _MapHeaderState extends State<MapHeader> {
     _timer?.cancel();
     if (_totalSeconds <= 0) return;
 
+    if (_secondsRemaining <= 0) {
+      _timer = Timer(const Duration(seconds: 1), () {
+        if (mounted) {
+          unawaited(_refreshCountdown());
+        }
+      });
+      return;
+    }
+
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) {
         _timer?.cancel();
@@ -54,10 +63,21 @@ class _MapHeaderState extends State<MapHeader> {
           _secondsRemaining--;
           if (_secondsRemaining == 0) {
             _timer?.cancel();
+            _timer = Timer(const Duration(seconds: 1), () {
+              if (mounted) {
+                unawaited(_refreshCountdown());
+              }
+            });
           }
         }
       });
     });
+  }
+
+  Future<void> _refreshCountdown() async {
+    final data = await ApiService.instance.loadMapHeader();
+    if (!mounted) return;
+    _startCountdown(data);
   }
 
   double get _progress =>


### PR DESCRIPTION
Fix the map timer stalling at 0:00 by triggering an automatic refresh when the countdown expires. Ensure the timer restarts once the updated header data is received to keep the display accurate.