### PR TITLE
Fix/stuck on acquiring gps

### DIFF
--- a/xact_frontend/lib/screens/lobby/create_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/create_lobby.dart
@@ -5,6 +5,7 @@ import 'package:xact_frontend/screens/lobby/define_game_area_screen.dart';
 import 'package:xact_frontend/screens/team/team_lobby.dart';
 import 'package:xact_frontend/services/app_session.dart';
 import 'package:xact_frontend/services/geofence_store.dart';
+import 'package:xact_frontend/services/location_service.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
 class CreateGameScreen extends StatefulWidget {
@@ -94,7 +95,8 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
         points: GeofenceStore.instance.points,
       );
 
-      if (!mounted) return;
+      final locationReady = await _ensureLocationReadyBeforeLobby();
+      if (!locationReady || !mounted) return;
 
       // Step 2: Enter the game.
       Navigator.push(
@@ -118,6 +120,47 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
         setState(() => _creating = false);
       }
     }
+  }
+
+  Future<bool> _ensureLocationReadyBeforeLobby() async {
+    while (mounted) {
+      final position = await LocationService.instance.getCurrentPosition(
+        timeLimit: const Duration(seconds: 10),
+      );
+      if (!mounted) return false;
+      if (position != null) {
+        return true;
+      }
+
+      final retry = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) {
+          return AlertDialog(
+            title: const Text('Location required'),
+            content: const Text(
+              'Please allow location access and ensure GPS is enabled before joining the lobby.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: const Text('Retry'),
+              ),
+            ],
+          );
+        },
+      );
+
+      if (retry != true) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   @override

--- a/xact_frontend/lib/screens/lobby/join_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/join_lobby.dart
@@ -5,6 +5,7 @@ import 'package:xact_frontend/api/models.dart';
 import 'package:xact_frontend/screens/lobby/scan_game_code.dart';
 import 'package:xact_frontend/screens/team/team_lobby.dart';
 import 'package:xact_frontend/services/app_session.dart';
+import 'package:xact_frontend/services/location_service.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
 class JoinGameScreen extends StatefulWidget {
@@ -123,7 +124,11 @@ class _JoinGameScreenState extends State<JoinGameScreen> {
         teamLeader: member.isTeamLeader,
       );
 
-      if (!mounted) return;
+      final locationReady = await _ensureLocationReadyBeforeLobby();
+      if (!locationReady || !mounted) {
+        return;
+      }
+
       Navigator.push(
         context,
         MaterialPageRoute(
@@ -148,6 +153,47 @@ class _JoinGameScreenState extends State<JoinGameScreen> {
         setState(() => _joining = false);
       }
     }
+  }
+
+  Future<bool> _ensureLocationReadyBeforeLobby() async {
+    while (mounted) {
+      final position = await LocationService.instance.getCurrentPosition(
+        timeLimit: const Duration(seconds: 10),
+      );
+      if (!mounted) return false;
+      if (position != null) {
+        return true;
+      }
+
+      final retry = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) {
+          return AlertDialog(
+            title: const Text('Location required'),
+            content: const Text(
+              'Please allow location access and ensure GPS is enabled before joining the lobby.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: const Text('Retry'),
+              ),
+            ],
+          );
+        },
+      );
+
+      if (retry != true) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   @override

--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -663,6 +663,7 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
     }
 
     _gameTransitionStarted = true;
+
     await GameStartTransitionService.instance.playCountdown(seconds: 3);
 
     if (!mounted) {
@@ -674,6 +675,7 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
       MaterialPageRoute(builder: (_) => const GameScreen()),
     );
   }
+
 }
 
 class _TeamUiConfig {

--- a/xact_frontend/lib/services/location_service.dart
+++ b/xact_frontend/lib/services/location_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../api/api_service.dart';
@@ -52,12 +53,18 @@ final class LocationService {
   /// Returns `true` if the user grants it (whileInUse or always).
   Future<bool> requestPermission() async {
     LocationPermission permission = await Geolocator.checkPermission();
+    //TODO: Remove Logger
+    //leaving logger in case it happens again
+    _log('LocationService: current permission = $permission');
 
     if (permission == LocationPermission.denied) {
+      _log('LocationService: requesting location permission');
       permission = await Geolocator.requestPermission();
+      _log('LocationService: permission result = $permission');
     }
 
     if (permission == LocationPermission.deniedForever) {
+      _log('LocationService: permission denied forever, opening app settings');
       // User blocked it permanently – open app settings so they can fix it.
       await Geolocator.openAppSettings();
       return false;
@@ -75,13 +82,24 @@ final class LocationService {
   Future<Position?> getCurrentPosition({
     Duration timeLimit = const Duration(seconds: 10),
   }) async {
+    _log('LocationService: getCurrentPosition start (timeout: $timeLimit)');
     try {
       final granted = await requestPermission();
-      if (!granted) return null;
+      if (!granted) {
+        _log(
+          'LocationService: getCurrentPosition aborted - permission not granted',
+        );
+        return null;
+      }
 
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      _log('LocationService: location service enabled = $serviceEnabled');
       if (!serviceEnabled) {
-        return await Geolocator.getLastKnownPosition();
+        final lastKnown = await Geolocator.getLastKnownPosition();
+        _log(
+          'LocationService: returning last known position because service is disabled: ${lastKnown != null}',
+        );
+        return lastKnown;
       }
 
       final position = await Geolocator.getCurrentPosition(
@@ -92,12 +110,23 @@ final class LocationService {
       );
       lastKnownPosition = position;
       _positionController.add(position);
+      _log(
+        'LocationService: getCurrentPosition success lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
+      );
       return position;
     } catch (_) {
+      _log(
+        'LocationService: getCurrentPosition failed, falling back to last known position',
+      );
       // Timeout or platform error – fall back to last known fix if we have one.
       try {
-        return await Geolocator.getLastKnownPosition();
+        final lastKnown = await Geolocator.getLastKnownPosition();
+        _log(
+          'LocationService: last known position available = ${lastKnown != null}',
+        );
+        return lastKnown;
       } catch (_) {
+        _log('LocationService: last known position lookup failed');
         return null;
       }
     }
@@ -110,22 +139,44 @@ final class LocationService {
   Future<void> startWatching() async {
     if (_positionSub != null) return; // already running
 
+    _log('LocationService: startWatching called');
     final granted = await requestPermission();
-    if (!granted) return;
+    if (!granted) {
+      _log('LocationService: startWatching aborted - permission not granted');
+      return;
+    }
 
     const locationSettings = LocationSettings(
       accuracy: LocationAccuracy.high,
       distanceFilter: 5,
     );
 
+    _log('LocationService: subscribing to position stream');
     _positionSub =
         Geolocator.getPositionStream(locationSettings: locationSettings).listen(
           (position) {
             lastKnownPosition = position;
             _positionController.add(position);
+            _log(
+              'LocationService: stream position lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
+            );
           },
-          onError: (_) {},
+          onError: (Object error) {
+            _log('LocationService: position stream error: $error');
+          },
         );
+
+    // Some devices take a while before the first stream event arrives.
+    // Prime the UI with a one-shot fix so the map does not stay stuck on the
+    // loading indicator if the stream is slow to emit.
+    if (lastKnownPosition == null) {
+      final primedPosition = await getCurrentPosition(
+        timeLimit: const Duration(seconds: 5),
+      );
+      if (primedPosition != null) {
+        lastKnownPosition = primedPosition;
+      }
+    }
   }
 
   /// Starts continuous GPS tracking and periodic upload to the backend.
@@ -144,12 +195,19 @@ final class LocationService {
     // If already tracking, stop first.
     stopTracking();
 
+    _log(
+      'LocationService: startTracking session=$sessionId member=$memberId team=$teamId interval=$uploadInterval',
+    );
+
     _memberId = memberId;
     _sessionId = sessionId;
     _teamId = teamId;
 
     final granted = await requestPermission();
-    if (!granted) return;
+    if (!granted) {
+      _log('LocationService: startTracking aborted - permission not granted');
+      return;
+    }
 
     const locationSettings = LocationSettings(
       accuracy: LocationAccuracy.high,
@@ -157,16 +215,30 @@ final class LocationService {
       distanceFilter: 5,
     );
 
+    _log('LocationService: subscribing to tracking stream');
     _positionSub =
         Geolocator.getPositionStream(locationSettings: locationSettings).listen(
           (position) {
             lastKnownPosition = position;
             _positionController.add(position);
+            _log(
+              'LocationService: tracking position lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
+            );
           },
           onError: (Object error) {
+            _log('LocationService: tracking stream error: $error');
             // Swallow errors so the stream stays alive.
           },
         );
+
+    if (lastKnownPosition == null) {
+      final primedPosition = await getCurrentPosition(
+        timeLimit: const Duration(seconds: 5),
+      );
+      if (primedPosition != null) {
+        lastKnownPosition = primedPosition;
+      }
+    }
 
     // Upload on a fixed interval so the backend is always up-to-date even
     // when the player is standing still (distanceFilter would skip those).
@@ -199,6 +271,9 @@ final class LocationService {
         sessionId == null ||
         memberId == null ||
         teamId == null) {
+      _log(
+        'LocationService: upload skipped (position=${position != null}, session=${sessionId != null}, member=${memberId != null}, team=${teamId != null})',
+      );
       return;
     }
 
@@ -214,8 +289,17 @@ final class LocationService {
         transportMode: 'Foot',
         isRevealedPosition: false,
       );
+      _log(
+        'LocationService: uploaded position member=$memberId lat=${position.latitude} lon=${position.longitude}',
+      );
     } catch (_) {
+      _log('LocationService: upload failed');
       // Don't crash – network may be temporarily unavailable.
     }
+  }
+
+  /// Simple debug logger that only prints in debug builds.
+  static void _log(String message) {
+    if (kDebugMode) debugPrint(message);
   }
 }

--- a/xact_frontend/lib/services/location_service.dart
+++ b/xact_frontend/lib/services/location_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../api/api_service.dart';
@@ -42,29 +41,16 @@ final class LocationService {
 
   // ── Public API ────────────────────────────────────────────────────────────
 
-  /// Returns `true` when the app already has location permission.
-  Future<bool> hasPermission() async {
-    final perm = await Geolocator.checkPermission();
-    return perm == LocationPermission.whileInUse ||
-        perm == LocationPermission.always;
-  }
-
   /// Requests location permission from the OS.
   /// Returns `true` if the user grants it (whileInUse or always).
   Future<bool> requestPermission() async {
     LocationPermission permission = await Geolocator.checkPermission();
-    //TODO: Remove Logger
-    //leaving logger in case it happens again
-    _log('LocationService: current permission = $permission');
 
     if (permission == LocationPermission.denied) {
-      _log('LocationService: requesting location permission');
       permission = await Geolocator.requestPermission();
-      _log('LocationService: permission result = $permission');
     }
 
     if (permission == LocationPermission.deniedForever) {
-      _log('LocationService: permission denied forever, opening app settings');
       // User blocked it permanently – open app settings so they can fix it.
       await Geolocator.openAppSettings();
       return false;
@@ -82,23 +68,15 @@ final class LocationService {
   Future<Position?> getCurrentPosition({
     Duration timeLimit = const Duration(seconds: 10),
   }) async {
-    _log('LocationService: getCurrentPosition start (timeout: $timeLimit)');
     try {
       final granted = await requestPermission();
       if (!granted) {
-        _log(
-          'LocationService: getCurrentPosition aborted - permission not granted',
-        );
         return null;
       }
 
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
-      _log('LocationService: location service enabled = $serviceEnabled');
       if (!serviceEnabled) {
         final lastKnown = await Geolocator.getLastKnownPosition();
-        _log(
-          'LocationService: returning last known position because service is disabled: ${lastKnown != null}',
-        );
         return lastKnown;
       }
 
@@ -110,23 +88,13 @@ final class LocationService {
       );
       lastKnownPosition = position;
       _positionController.add(position);
-      _log(
-        'LocationService: getCurrentPosition success lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
-      );
       return position;
     } catch (_) {
-      _log(
-        'LocationService: getCurrentPosition failed, falling back to last known position',
-      );
       // Timeout or platform error – fall back to last known fix if we have one.
       try {
         final lastKnown = await Geolocator.getLastKnownPosition();
-        _log(
-          'LocationService: last known position available = ${lastKnown != null}',
-        );
         return lastKnown;
       } catch (_) {
-        _log('LocationService: last known position lookup failed');
         return null;
       }
     }
@@ -139,10 +107,8 @@ final class LocationService {
   Future<void> startWatching() async {
     if (_positionSub != null) return; // already running
 
-    _log('LocationService: startWatching called');
     final granted = await requestPermission();
     if (!granted) {
-      _log('LocationService: startWatching aborted - permission not granted');
       return;
     }
 
@@ -151,32 +117,14 @@ final class LocationService {
       distanceFilter: 5,
     );
 
-    _log('LocationService: subscribing to position stream');
     _positionSub =
         Geolocator.getPositionStream(locationSettings: locationSettings).listen(
           (position) {
             lastKnownPosition = position;
             _positionController.add(position);
-            _log(
-              'LocationService: stream position lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
-            );
           },
-          onError: (Object error) {
-            _log('LocationService: position stream error: $error');
-          },
+          onError: (_) {},
         );
-
-    // Some devices take a while before the first stream event arrives.
-    // Prime the UI with a one-shot fix so the map does not stay stuck on the
-    // loading indicator if the stream is slow to emit.
-    if (lastKnownPosition == null) {
-      final primedPosition = await getCurrentPosition(
-        timeLimit: const Duration(seconds: 5),
-      );
-      if (primedPosition != null) {
-        lastKnownPosition = primedPosition;
-      }
-    }
   }
 
   /// Starts continuous GPS tracking and periodic upload to the backend.
@@ -195,9 +143,6 @@ final class LocationService {
     // If already tracking, stop first.
     stopTracking();
 
-    _log(
-      'LocationService: startTracking session=$sessionId member=$memberId team=$teamId interval=$uploadInterval',
-    );
 
     _memberId = memberId;
     _sessionId = sessionId;
@@ -205,7 +150,6 @@ final class LocationService {
 
     final granted = await requestPermission();
     if (!granted) {
-      _log('LocationService: startTracking aborted - permission not granted');
       return;
     }
 
@@ -215,30 +159,14 @@ final class LocationService {
       distanceFilter: 5,
     );
 
-    _log('LocationService: subscribing to tracking stream');
     _positionSub =
         Geolocator.getPositionStream(locationSettings: locationSettings).listen(
           (position) {
             lastKnownPosition = position;
             _positionController.add(position);
-            _log(
-              'LocationService: tracking position lat=${position.latitude} lon=${position.longitude} acc=${position.accuracy}',
-            );
           },
-          onError: (Object error) {
-            _log('LocationService: tracking stream error: $error');
-            // Swallow errors so the stream stays alive.
-          },
+          onError: (_) {},
         );
-
-    if (lastKnownPosition == null) {
-      final primedPosition = await getCurrentPosition(
-        timeLimit: const Duration(seconds: 5),
-      );
-      if (primedPosition != null) {
-        lastKnownPosition = primedPosition;
-      }
-    }
 
     // Upload on a fixed interval so the backend is always up-to-date even
     // when the player is standing still (distanceFilter would skip those).
@@ -271,9 +199,6 @@ final class LocationService {
         sessionId == null ||
         memberId == null ||
         teamId == null) {
-      _log(
-        'LocationService: upload skipped (position=${position != null}, session=${sessionId != null}, member=${memberId != null}, team=${teamId != null})',
-      );
       return;
     }
 
@@ -289,17 +214,8 @@ final class LocationService {
         transportMode: 'Foot',
         isRevealedPosition: false,
       );
-      _log(
-        'LocationService: uploaded position member=$memberId lat=${position.latitude} lon=${position.longitude}',
-      );
     } catch (_) {
-      _log('LocationService: upload failed');
       // Don't crash – network may be temporarily unavailable.
     }
-  }
-
-  /// Simple debug logger that only prints in debug builds.
-  static void _log(String message) {
-    if (kDebugMode) debugPrint(message);
   }
 }

--- a/xact_frontend/lib/widgets/map_area.dart
+++ b/xact_frontend/lib/widgets/map_area.dart
@@ -237,27 +237,26 @@ class _MapAreaState extends State<MapArea> {
 
     // Use the last known position immediately if available (no wait needed).
     final existing = LocationService.instance.lastKnownPosition;
-    if (existing != null && mounted) {
-      final latLng = LatLng(existing.latitude, existing.longitude);
-      setState(() {
-        _myPosition = latLng;
-        _isOutOfBounds = _checkOutOfBounds(latLng);
-      });
+    if (existing != null) {
+      _applyPosition(existing);
     }
 
     // Subscribe to live updates.
-    _positionSub = LocationService.instance.positionStream.listen((pos) {
-      if (!mounted) return;
-      final latLng = LatLng(pos.latitude, pos.longitude);
-      setState(() {
-        _myPosition = latLng;
-        _isOutOfBounds = _checkOutOfBounds(latLng);
-      });
+    _positionSub = LocationService.instance.positionStream.listen(_applyPosition);
 
-      if (_followMode) {
-        _mapController.move(latLng, _mapController.camera.zoom);
-      }
+  }
+
+  void _applyPosition(Position pos) {
+    if (!mounted) return;
+    final latLng = LatLng(pos.latitude, pos.longitude);
+    setState(() {
+      _myPosition = latLng;
+      _isOutOfBounds = _checkOutOfBounds(latLng);
     });
+
+    if (_followMode) {
+      _mapController.move(latLng, _mapController.camera.zoom);
+    }
   }
 
   /// Returns true when [point] lies outside the [_geofencePoints] polygon.


### PR DESCRIPTION
Improves Reliability of location handling when creating or joining a game lobby. The main changes ensure that location permissions are checked and the user's location is available before proceeding, and that users are prompted to enable location services if necessary. Additionally, there are some refactors and minor improvements to the location service and map widget.

**Lobby flow improvements:**

* Both `CreateGameScreen` and `JoinGameScreen` now require a valid location before allowing users to enter the lobby. If location is unavailable, a dialog prompts the user to enable location services or retry, and cancels the flow if declined.

**Location service improvements:**

* Refactored `LocationService` to consistently check for permissions, return last known location as a fallback, and simplify error handling in its API. Unused `hasPermission()` method was removed. 
**Map widget refactor:**

* Refactored `_MapAreaState` to use a dedicated `_applyPosition` method for updating the user's position, improving code clarity and reusability. 
