### PR TITLE
fix: avoid full-screen reload when host drags a player between teams

### DIFF
--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -455,7 +455,7 @@ class _GameLobbyScreenState extends State<GameLobbyScreen> {
         targetTeamId: targetTeamId,
       );
       if (refreshAfterMove) {
-        await _refreshLobby();
+        await _refreshLobby(silent: true);
       }
     } catch (error) {
       if (!mounted) return;


### PR DESCRIPTION
_movePlayer awaited a non-silent _refreshLobby after moving a member, which flipped _loading back to true and replaced the lobby with the CircularProgressIndicator for one frame. Switching that follow-up refresh to silent keeps the existing teams rendered and lets the moved player slide into place once the snapshot data updates.

This PR is only 1 line change but implementation still required a branch and approval via PR to merge.