### PR TITLE
refactor: smarter game-area corner placement and post-save loading view

### DIFF
--- a/xact_frontend/lib/screens/lobby/create_lobby.dart
+++ b/xact_frontend/lib/screens/lobby/create_lobby.dart
@@ -18,6 +18,7 @@ class CreateGameScreen extends StatefulWidget {
 class _CreateGameScreenState extends State<CreateGameScreen> {
   final _gameNameController = TextEditingController();
   bool _creating = false;
+  bool _finalizingLobby = false;
 
   @override
   void dispose() {
@@ -77,6 +78,12 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
         ),
       );
 
+      // While the host is defining the game area, the create-game form is
+      // still mounted underneath; flipping this flag now means the moment
+      // the area screen pops we reveal a loading view instead of the form
+      // briefly reappearing.
+      setState(() => _finalizingLobby = true);
+
       // Step 1: Let the host define the game area.
       final areaSaved = await Navigator.push<bool>(
         context,
@@ -88,7 +95,10 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
         ),
       );
 
-      if (areaSaved != true || !mounted) return;
+      if (areaSaved != true || !mounted) {
+        if (mounted) setState(() => _finalizingLobby = false);
+        return;
+      }
 
       await ApiService.instance.saveGeofenceArea(
         sessionId: sessionId,
@@ -96,10 +106,13 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
       );
 
       final locationReady = await _ensureLocationReadyBeforeLobby();
-      if (!locationReady || !mounted) return;
+      if (!locationReady || !mounted) {
+        if (mounted) setState(() => _finalizingLobby = false);
+        return;
+      }
 
       // Step 2: Enter the game.
-      Navigator.push(
+      Navigator.pushReplacement(
         context,
         MaterialPageRoute(
           builder: (context) => GameLobbyScreen(
@@ -168,25 +181,44 @@ class _CreateGameScreenState extends State<CreateGameScreen> {
     return Scaffold(
       backgroundColor: XActBranding.backgroundColor,
       body: SafeArea(
-        child: SingleChildScrollView(
-          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-          padding: EdgeInsets.fromLTRB(
-            24,
-            24,
-            24,
-            16 + MediaQuery.of(context).viewInsets.bottom,
+        child: _finalizingLobby
+            ? _buildPreparingLobbyView()
+            : SingleChildScrollView(
+                keyboardDismissBehavior:
+                    ScrollViewKeyboardDismissBehavior.onDrag,
+                padding: EdgeInsets.fromLTRB(
+                  24,
+                  24,
+                  24,
+                  16 + MediaQuery.of(context).viewInsets.bottom,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    XActBranding.buildHeader(),
+                    const SizedBox(height: 32),
+                    _buildCreateForm(),
+                    const SizedBox(height: 16),
+                    XActBranding.buildFooter(),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+
+  Widget _buildPreparingLobbyView() {
+    return const Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(color: Colors.blue),
+          SizedBox(height: 20),
+          Text(
+            'Preparing your lobby…',
+            style: TextStyle(color: Colors.white, fontSize: 16),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              XActBranding.buildHeader(),
-              const SizedBox(height: 32),
-              _buildCreateForm(),
-              const SizedBox(height: 16),
-              XActBranding.buildFooter(),
-            ],
-          ),
-        ),
+        ],
       ),
     );
   }

--- a/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
+++ b/xact_frontend/lib/screens/lobby/define_game_area_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -120,10 +122,40 @@ class _DefineGameAreaScreenState extends State<DefineGameAreaScreen> {
     }
 
     setState(() {
-      _points.add(point);
+      _points.insert(_bestInsertIndex(point), point);
       _selectedIndex = -1;
       _isMoveMode = false;
     });
+  }
+
+  // Returns the index at which [point] should be inserted so that it lands
+  // between the two existing corners that form the closest edge. This keeps
+  // the polygon shape natural instead of always appending chronologically.
+  int _bestInsertIndex(LatLng point) {
+    final n = _points.length;
+    if (n < 3) return n;
+
+    var bestIndex = n;
+    var bestCost = double.infinity;
+    for (var i = 0; i < n; i++) {
+      final a = _points[i];
+      final b = _points[(i + 1) % n];
+      final cost =
+          _planarDistance(point, a) +
+          _planarDistance(point, b) -
+          _planarDistance(a, b);
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestIndex = i + 1;
+      }
+    }
+    return bestIndex;
+  }
+
+  double _planarDistance(LatLng a, LatLng b) {
+    final dLat = a.latitude - b.latitude;
+    final dLng = a.longitude - b.longitude;
+    return math.sqrt(dLat * dLat + dLng * dLng);
   }
 
   void _deletePointAt(int index) {


### PR DESCRIPTION
- New game-area corners are now inserted between the two adjacent existing corners with the smallest perimeter increase (closest edge), so taps land naturally inside the polygon instead of always being chained to the last-placed corner. Falls back to plain append for fewer than three points.
- Replaced the brief "back to the create-game form" flicker that happened between saving the area and entering the lobby with a centered "Preparing your lobby…" loading view. The lobby is now pushed via `pushReplacement` so the create-game route is left behind cleanly.