### PR TITLE
Swap Mr. X role upon capture

### DIFF
--- a/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
+++ b/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
@@ -18,6 +18,7 @@ public interface IGameSessionRealtimePublisher
     public ValueTask PublishTeamMemberLeftAsync(int sessionId, int teamId, int memberId, int? userId, string? guestName, Instant leftAt);
     public ValueTask PublishGameSessionStartedAsync(GameSession gameSession);
     public ValueTask PublishLocationLogRecordedAsync(int sessionId, int teamId, LocationLog log);
+    public ValueTask PublishMrXCaughtAsync(Team newMrXTeam, Team formerMrXTeam);
 }
 
 internal sealed class GameSessionSnapshotService(

--- a/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
+++ b/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
@@ -18,6 +18,7 @@ public static class RealtimeEvents
     public const string TeamMemberLeft = "team_member_left";
     public const string GameSessionStarted = "game_session_started";
     public const string LocationLogRecorded = "location_log_recorded";
+    public const string MrXCaught = "mr_x_caught";
 }
 
 public static class RealtimeGroups
@@ -138,6 +139,14 @@ public sealed record GameSessionStartedPayload(
     SessionStatus Status,
     Instant? StartTime,
     Instant? EndTime
+);
+
+public sealed record MrXCaughtPayload(
+    int SessionId,
+    int NewMrXTeamId,
+    string NewMrXTeamName,
+    int FormerMrXTeamId,
+    string FormerMrXTeamName
 );
 
 public sealed record LocationLogRecordedPayload(

--- a/backend/XActBackend.Core/Services/DomainError.cs
+++ b/backend/XActBackend.Core/Services/DomainError.cs
@@ -11,6 +11,7 @@ public static class DomainErrorCodes
     public const string SessionNotJoinable = "session_not_joinable";
     public const string SessionNotActive = "session_not_active";
     public const string MrXTeamAlreadyExists = "mr_x_team_already_exists";
+    public const string CatchingTeamNotEligible = "catching_team_not_eligible";
     public const string TeamHasMembers = "team_has_members";
     public const string InvalidMemberIdentity = "invalid_member_identity";
     public const string TeamNotInSession = "team_not_in_session";
@@ -46,6 +47,10 @@ public sealed record DomainError(string Code, string Message)
 
     public static DomainError MrXTeamAlreadyExists(int sessionId) =>
         new(DomainErrorCodes.MrXTeamAlreadyExists, $"Session {sessionId} already has an Mr.X team.");
+
+    public static DomainError CatchingTeamNotEligible(int teamId, TeamRole role) =>
+        new(DomainErrorCodes.CatchingTeamNotEligible,
+            $"Team {teamId} has role {role} and cannot catch Mr.X; only a detective team can.");
 
     public static DomainError TeamHasMembers(int teamId) =>
         new(DomainErrorCodes.TeamHasMembers, $"Team {teamId} still has members and cannot be deleted.");

--- a/backend/XActBackend.Core/Services/GameSessionService.cs
+++ b/backend/XActBackend.Core/Services/GameSessionService.cs
@@ -72,11 +72,13 @@ public interface IGameSessionService
     public ValueTask<OneOf<Success, NotFound, DomainError>> EndGameSessionAsync(int sessionId);
 
     /// <summary>
-    ///     Mark Mr.X as caught for a game session.
+    ///     Mark Mr.X as caught by a detective team and swap the two teams' roles: the catching
+    ///     team becomes the new Mr.X team and the former Mr.X team becomes a detective team.
     /// </summary>
     /// <param name="sessionId">The id of the game session</param>
-    /// <returns>Result indicating if Mr.X could be marked as caught</returns>
-    public ValueTask<OneOf<Success, NotFound, DomainError>> CatchMrXAsync(int sessionId);
+    /// <param name="catchingTeamId">The id of the detective team that caught Mr.X</param>
+    /// <returns>The swapped teams, or an error if the catch could not be processed</returns>
+    public ValueTask<OneOf<MrXCaughtResult, NotFound, DomainError>> CatchMrXAsync(int sessionId, int catchingTeamId);
 
     /// <summary>
     ///     Data used to create or update a game session.
@@ -99,6 +101,13 @@ public interface IGameSessionService
         int PlannedDurationMinutes = 60,
         int MrXRevealInterval = 5
     );
+
+    /// <summary>
+    ///     The outcome of a successful Mr.X catch: the two teams whose roles were swapped.
+    /// </summary>
+    /// <param name="NewMrXTeam">The team that caught Mr.X and is now the Mr.X team</param>
+    /// <param name="FormerMrXTeam">The team that was Mr.X and is now a detective team</param>
+    public sealed record MrXCaughtResult(Team NewMrXTeam, Team FormerMrXTeam);
 }
 
 internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<GameSessionService> logger) : IGameSessionService
@@ -340,7 +349,7 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
         return new Success();
     }
 
-    public async ValueTask<OneOf<Success, NotFound, DomainError>> CatchMrXAsync(int sessionId)
+    public async ValueTask<OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError>> CatchMrXAsync(int sessionId, int catchingTeamId)
     {
         var gameSession = await uow.GameSessionRepository.GetSessionByIdAsync(sessionId, tracking: false);
         if (gameSession is null)
@@ -361,13 +370,42 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
             return new NotFound();
         }
 
-        mrXTeam.IsCaught = true;
+        var catchingTeam = await uow.TeamRepository.GetTeamByIdAsync(catchingTeamId, tracking: true);
+        if (catchingTeam is null)
+        {
+            logger.LogWarning("Rejected catch for session {SessionId} because catching team {TeamId} was not found", sessionId, catchingTeamId);
+            return new NotFound();
+        }
+
+        if (catchingTeam.SessionId != sessionId)
+        {
+            logger.LogWarning("Rejected catch for session {SessionId} because catching team {TeamId} belongs to session {OtherSessionId}", sessionId, catchingTeamId, catchingTeam.SessionId);
+            return DomainError.TeamNotInSession(catchingTeamId, sessionId);
+        }
+
+        // Only a detective team can catch Mr.X. This also rejects the degenerate case where the
+        // caller passes the current Mr.X team (its role is MrX, not Detective) or a spectator team.
+        if (catchingTeam.Role != TeamRole.Detective)
+        {
+            logger.LogWarning("Rejected catch for session {SessionId} because catching team {TeamId} has role {Role}", sessionId, catchingTeamId, catchingTeam.Role);
+            return DomainError.CatchingTeamNotEligible(catchingTeamId, catchingTeam.Role);
+        }
+
+        // Swap roles: the catching team takes over as Mr.X, the former Mr.X becomes a detective team.
+        mrXTeam.Role = TeamRole.Detective;
+        mrXTeam.IsCaught = false;
+        catchingTeam.Role = TeamRole.MrX;
+        catchingTeam.IsCaught = false;
 
         await uow.SaveChangesAsync();
 
-        logger.LogInformation("MrX was caught in session {SessionId}, team {TeamId}", sessionId, mrXTeam.Id);
+        logger.LogInformation(
+            "MrX was caught in session {SessionId}: team {CatchingTeamId} is now MrX, former MrX team {FormerMrXTeamId} is now a detective team",
+            sessionId,
+            catchingTeam.Id,
+            mrXTeam.Id);
 
-        return new Success();
+        return new IGameSessionService.MrXCaughtResult(catchingTeam, mrXTeam);
     }
 
     private static bool IsValidStatusTransition(SessionStatus currentStatus, SessionStatus requestedStatus) =>

--- a/backend/XActBackend.Test/GameSessionServiceTests.cs
+++ b/backend/XActBackend.Test/GameSessionServiceTests.cs
@@ -521,13 +521,35 @@ public sealed class GameSessionServiceTests
 
     // --- CatchMrXAsync ---
 
+    private const int DefaultCatchingTeamId = 20;
+
+    private Team ArrangeActiveCatchScenario(
+        out Team mrXTeam,
+        TeamRole catchingRole = TeamRole.Detective,
+        int catchingTeamSessionId = DefaultSessionId)
+    {
+        var session = CreateSession();
+        session.Status = SessionStatus.Active;
+        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
+
+        mrXTeam = CreateTeam(10, "MrX Team", TeamRole.MrX, "#000000");
+        mrXTeam.SessionId = DefaultSessionId;
+        _teamRepository.GetTeamBySessionAndRoleAsync(DefaultSessionId, TeamRole.MrX, true).Returns(mrXTeam);
+
+        var catchingTeam = CreateTeam(DefaultCatchingTeamId, "Detective Team", catchingRole, "#2563EB");
+        catchingTeam.SessionId = catchingTeamSessionId;
+        _teamRepository.GetTeamByIdAsync(DefaultCatchingTeamId, true).Returns(catchingTeam);
+
+        return catchingTeam;
+    }
+
     [Fact]
     public async ValueTask CatchMrXAsync_ReturnsNotFound_WhenSessionMissing()
     {
         _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns((GameSession?) null);
-        OneOf<Success, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
         result.Switch(
-            _ => Assert.Fail("Expected NotFound but got Success"),
+            _ => Assert.Fail("Expected NotFound but got MrXCaughtResult"),
             _ => { /* expected */ },
             _ => Assert.Fail("Expected NotFound but got DomainError")
         );
@@ -539,9 +561,9 @@ public sealed class GameSessionServiceTests
         var session = CreateSession();
         session.Status = SessionStatus.Waiting;
         _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
-        OneOf<Success, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
         result.Switch(
-            _ => Assert.Fail("Expected DomainError but got Success"),
+            _ => Assert.Fail("Expected DomainError but got MrXCaughtResult"),
             _ => Assert.Fail("Expected DomainError but got NotFound"),
             domainError => domainError.Code.Should().Be(DomainErrorCodes.SessionNotActive)
         );
@@ -554,29 +576,70 @@ public sealed class GameSessionServiceTests
         session.Status = SessionStatus.Active;
         _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
         _teamRepository.GetTeamBySessionAndRoleAsync(DefaultSessionId, TeamRole.MrX, true).Returns((Team?) null);
-        OneOf<Success, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
         result.Switch(
-            _ => Assert.Fail("Expected NotFound but got Success"),
+            _ => Assert.Fail("Expected NotFound but got MrXCaughtResult"),
             _ => { /* expected */ },
             _ => Assert.Fail("Expected NotFound but got DomainError")
         );
     }
 
     [Fact]
-    public async ValueTask CatchMrXAsync_ReturnsSuccess_WhenActive()
+    public async ValueTask CatchMrXAsync_ReturnsNotFound_WhenCatchingTeamMissing()
     {
-        var session = CreateSession();
-        session.Status = SessionStatus.Active;
-        var mrXTeam = CreateTeam(10, "MrX Team", TeamRole.MrX, "#000000");
-        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
-        _teamRepository.GetTeamBySessionAndRoleAsync(DefaultSessionId, TeamRole.MrX, true).Returns(mrXTeam);
-        OneOf<Success, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId);
+        ArrangeActiveCatchScenario(out _);
+        _teamRepository.GetTeamByIdAsync(DefaultCatchingTeamId, true).Returns((Team?) null);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
         result.Switch(
+            _ => Assert.Fail("Expected NotFound but got MrXCaughtResult"),
             _ => { /* expected */ },
-            _ => Assert.Fail("Expected Success but got NotFound"),
-            _ => Assert.Fail("Expected Success but got DomainError")
+            _ => Assert.Fail("Expected NotFound but got DomainError")
         );
-        mrXTeam.IsCaught.Should().BeTrue();
+    }
+
+    [Fact]
+    public async ValueTask CatchMrXAsync_ReturnsDomainError_WhenCatchingTeamNotInSession()
+    {
+        ArrangeActiveCatchScenario(out _, catchingTeamSessionId: DefaultSessionId + 1);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
+        result.Switch(
+            _ => Assert.Fail("Expected DomainError but got MrXCaughtResult"),
+            _ => Assert.Fail("Expected DomainError but got NotFound"),
+            domainError => domainError.Code.Should().Be(DomainErrorCodes.TeamNotInSession)
+        );
+    }
+
+    [Fact]
+    public async ValueTask CatchMrXAsync_ReturnsDomainError_WhenCatchingTeamNotDetective()
+    {
+        ArrangeActiveCatchScenario(out _, catchingRole: TeamRole.Spectator);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
+        result.Switch(
+            _ => Assert.Fail("Expected DomainError but got MrXCaughtResult"),
+            _ => Assert.Fail("Expected DomainError but got NotFound"),
+            domainError => domainError.Code.Should().Be(DomainErrorCodes.CatchingTeamNotEligible)
+        );
+    }
+
+    [Fact]
+    public async ValueTask CatchMrXAsync_SwapsRoles_WhenActive()
+    {
+        var catchingTeam = ArrangeActiveCatchScenario(out var mrXTeam);
+        OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result = await _sut.CatchMrXAsync(DefaultSessionId, DefaultCatchingTeamId);
+        result.Switch(
+            caught =>
+            {
+                caught.NewMrXTeam.Should().BeSameAs(catchingTeam);
+                caught.FormerMrXTeam.Should().BeSameAs(mrXTeam);
+            },
+            _ => Assert.Fail("Expected MrXCaughtResult but got NotFound"),
+            _ => Assert.Fail("Expected MrXCaughtResult but got DomainError")
+        );
+
+        catchingTeam.Role.Should().Be(TeamRole.MrX);
+        mrXTeam.Role.Should().Be(TeamRole.Detective);
+        catchingTeam.IsCaught.Should().BeFalse();
+        mrXTeam.IsCaught.Should().BeFalse();
         await _uow.Received(1).SaveChangesAsync();
     }
 }

--- a/backend/XActBackend.TestInt/GameSessionControllerTests.cs
+++ b/backend/XActBackend.TestInt/GameSessionControllerTests.cs
@@ -225,8 +225,7 @@ public sealed class GameSessionControllerTests(WebApiTestFixture fixture) : Seed
 
     // --- CatchMrX ---
 
-    [Fact]
-    public async ValueTask CatchMrX_NoContent()
+    private async ValueTask ActivateSeededSessionAsync()
     {
         await ModifyDatabaseContentAsync(context =>
         {
@@ -234,16 +233,43 @@ public sealed class GameSessionControllerTests(WebApiTestFixture fixture) : Seed
             session!.Status = SessionStatus.Active;
             return new ValueTask(context.SaveChangesAsync());
         });
+    }
 
-        var response = await ApiClient.PostAsync($"{BaseUrl}/{SeedData.SessionId}/catch", null, TestCancellationToken);
+    [Fact]
+    public async ValueTask CatchMrX_NoContent_AndSwapsRoles()
+    {
+        await ActivateSeededSessionAsync();
+
+        var request = new CatchMrXRequest(SeedData.DetectiveTeamId);
+        var response = await ApiClient.PostAsJsonAsync($"{BaseUrl}/{SeedData.SessionId}/catch", request, JsonOptions, TestCancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // The catching detective team is now Mr.X, and the former Mr.X team is now a detective team.
+        var formerMrX = await ApiClient.GetAsync($"{BaseUrl}/{SeedData.SessionId}/teams/{SeedData.MrXTeamId}", TestCancellationToken);
+        var newMrX = await ApiClient.GetAsync($"{BaseUrl}/{SeedData.SessionId}/teams/{SeedData.DetectiveTeamId}", TestCancellationToken);
+        var formerMrXTeam = await formerMrX.Content.ReadFromJsonAsync<TeamDetailsDto>(JsonOptions, TestCancellationToken);
+        var newMrXTeam = await newMrX.Content.ReadFromJsonAsync<TeamDetailsDto>(JsonOptions, TestCancellationToken);
+        formerMrXTeam!.Role.Should().Be(TeamRole.Detective);
+        newMrXTeam!.Role.Should().Be(TeamRole.MrX);
+    }
+
+    [Fact]
+    public async ValueTask CatchMrX_BadRequest_WhenCatchingTeamIdInvalid()
+    {
+        await ActivateSeededSessionAsync();
+
+        var request = new CatchMrXRequest(0);
+        var response = await ApiClient.PostAsJsonAsync($"{BaseUrl}/{SeedData.SessionId}/catch", request, JsonOptions, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async ValueTask CatchMrX_NotFound()
     {
-        var response = await ApiClient.PostAsync($"{BaseUrl}/9999/catch", null, TestCancellationToken);
+        var request = new CatchMrXRequest(SeedData.DetectiveTeamId);
+        var response = await ApiClient.PostAsJsonAsync($"{BaseUrl}/9999/catch", request, JsonOptions, TestCancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
@@ -251,7 +277,20 @@ public sealed class GameSessionControllerTests(WebApiTestFixture fixture) : Seed
     [Fact]
     public async ValueTask CatchMrX_Conflict_WhenNotActive()
     {
-        var response = await ApiClient.PostAsync($"{BaseUrl}/{SeedData.SessionId}/catch", null, TestCancellationToken);
+        var request = new CatchMrXRequest(SeedData.DetectiveTeamId);
+        var response = await ApiClient.PostAsJsonAsync($"{BaseUrl}/{SeedData.SessionId}/catch", request, JsonOptions, TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async ValueTask CatchMrX_Conflict_WhenCatchingTeamIsNotDetective()
+    {
+        await ActivateSeededSessionAsync();
+
+        // The current Mr.X team is not a detective team and therefore cannot "catch" Mr.X.
+        var request = new CatchMrXRequest(SeedData.MrXTeamId);
+        var response = await ApiClient.PostAsJsonAsync($"{BaseUrl}/{SeedData.SessionId}/catch", request, JsonOptions, TestCancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }

--- a/backend/XActBackend/Controllers/GameSessionController.cs
+++ b/backend/XActBackend/Controllers/GameSessionController.cs
@@ -312,26 +312,41 @@ public sealed class GameSessionController(
     [HttpPost]
     [Route("{sessionId:int}/catch")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
-    public async ValueTask<IActionResult> CatchMrX([FromRoute] int sessionId)
+    public async ValueTask<IActionResult> CatchMrX([FromRoute] int sessionId, [FromBody] CatchMrXRequest request)
     {
+        if (!ValidateRequest<CatchMrXRequest.Validator, CatchMrXRequest>(request))
+        {
+            logger.LogWarning("Rejected catch for game session {SessionId} because validation failed", sessionId);
+            return BadRequest();
+        }
+
         try
         {
             await transaction.BeginTransactionAsync();
 
-            OneOf<Success, NotFound, DomainError> result = await gameSessionService.CatchMrXAsync(sessionId);
+            OneOf<IGameSessionService.MrXCaughtResult, NotFound, DomainError> result =
+                await gameSessionService.CatchMrXAsync(sessionId, request.CatchingTeamId);
 
-            return await result.Match<ValueTask<IActionResult>>(async success =>
+            return await result.Match<ValueTask<IActionResult>>(async caught =>
             {
                 await transaction.CommitAsync();
-                logger.LogInformation("MrX was caught in game session {SessionId}", sessionId);
+
+                // Both teams changed role, so push the updated team state to every client and
+                // announce the swap so each client can surface it to the player.
+                await realtimePublisher.PublishTeamUpdatedAsync(caught.NewMrXTeam);
+                await realtimePublisher.PublishTeamUpdatedAsync(caught.FormerMrXTeam);
+                await realtimePublisher.PublishMrXCaughtAsync(caught.NewMrXTeam, caught.FormerMrXTeam);
+
+                logger.LogInformation("MrX was caught in game session {SessionId}: team {NewMrXTeamId} is now MrX", sessionId, caught.NewMrXTeam.Id);
 
                 return NoContent();
             }, async notFound =>
             {
                 await transaction.RollbackAsync();
-                logger.LogWarning("Rejected catch for game session {SessionId} because session or MrX team was not found", sessionId);
+                logger.LogWarning("Rejected catch for game session {SessionId} because session, MrX team or catching team was not found", sessionId);
 
                 return NotFound();
             }, async domainError =>
@@ -348,6 +363,17 @@ public sealed class GameSessionController(
             await transaction.RollbackAsync();
 
             return Problem();
+        }
+    }
+}
+
+public sealed record CatchMrXRequest(int CatchingTeamId)
+{
+    public sealed class Validator : AbstractValidator<CatchMrXRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.CatchingTeamId).GreaterThan(0);
         }
     }
 }

--- a/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
+++ b/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
@@ -103,6 +103,17 @@ internal sealed class GameSessionRealtimePublisher(
                 log.TransportMode,
                 log.IsRevealedPosition));
 
+    public ValueTask PublishMrXCaughtAsync(Team newMrXTeam, Team formerMrXTeam) =>
+        PublishToSessionAsync(
+            newMrXTeam.SessionId,
+            RealtimeEvents.MrXCaught,
+            new MrXCaughtPayload(
+                newMrXTeam.SessionId,
+                newMrXTeam.Id,
+                newMrXTeam.TeamName,
+                formerMrXTeam.Id,
+                formerMrXTeam.TeamName));
+
     private async ValueTask PublishToSessionAsync(int sessionId, string eventType, object payload)
     {
         try

--- a/backend/XActBackend/Util/BaseController.cs
+++ b/backend/XActBackend/Util/BaseController.cs
@@ -24,6 +24,7 @@ public abstract class BaseController : ControllerBase
             DomainErrorCodes.SessionNotJoinable => StatusCodes.Status409Conflict,
             DomainErrorCodes.SessionNotActive => StatusCodes.Status409Conflict,
             DomainErrorCodes.MrXTeamAlreadyExists => StatusCodes.Status409Conflict,
+            DomainErrorCodes.CatchingTeamNotEligible => StatusCodes.Status409Conflict,
             DomainErrorCodes.TeamHasMembers => StatusCodes.Status409Conflict,
             DomainErrorCodes.UserDeleted => StatusCodes.Status409Conflict,
             DomainErrorCodes.UserAlreadyJoined => StatusCodes.Status409Conflict,

--- a/xact_frontend/lib/api/api_service_data.dart
+++ b/xact_frontend/lib/api/api_service_data.dart
@@ -23,6 +23,7 @@ extension ApiServiceDataMethods on ApiService {
               .toList(growable: false);
 
           return TeamCardData(
+            teamId: team.teamId,
             teamName: team.teamName,
             role: team.role,
             color: color,

--- a/xact_frontend/lib/api/api_service_http.dart
+++ b/xact_frontend/lib/api/api_service_http.dart
@@ -117,6 +117,25 @@ extension ApiServiceHttpMethods on ApiService {
     }
   }
 
+  Future<void> _postJsonNoContent(
+    String path,
+    Map<String, dynamic> payload,
+  ) async {
+    final uri = _baseUri.resolve(path);
+    final response = await _http.post(
+      uri,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('HTTP ${response.statusCode} for POST $path');
+    }
+  }
+
   Future<void> _putJsonNoContent(
     String path,
     Map<String, dynamic> payload,

--- a/xact_frontend/lib/api/api_service_session.dart
+++ b/xact_frontend/lib/api/api_service_session.dart
@@ -235,6 +235,18 @@ extension ApiServiceSessionMethods on ApiService {
     });
   }
 
+  /// Reports that the current Mr. X team was caught by [catchingTeamId], which
+  /// triggers the backend to swap the two teams' roles. The resulting role
+  /// changes arrive via realtime team_updated + mr_x_caught events.
+  Future<void> markMrXCaught({
+    required int sessionId,
+    required int catchingTeamId,
+  }) async {
+    await _postJsonNoContent('/api/gamesessions/$sessionId/catch', {
+      'catchingTeamId': catchingTeamId,
+    });
+  }
+
   Future<void> registerCurrentMemberPresence() async {
     final sessionId = _session.currentSessionId;
     final teamId = _session.currentTeamId;

--- a/xact_frontend/lib/api/api_service_types.dart
+++ b/xact_frontend/lib/api/api_service_types.dart
@@ -1,6 +1,7 @@
 part of 'api_service.dart';
 
 final class TeamCardData {
+  final int teamId;
   final String teamName;
   final TeamRole? role;
   final Color color;
@@ -8,6 +9,7 @@ final class TeamCardData {
   final List<String> members;
 
   const TeamCardData({
+    required this.teamId,
     required this.teamName,
     required this.role,
     required this.color,

--- a/xact_frontend/lib/api/models.dart
+++ b/xact_frontend/lib/api/models.dart
@@ -617,6 +617,7 @@ final class RealtimeEvents {
   static const String teamMemberLeft = 'team_member_left';
   static const String gameSessionStarted = 'game_session_started';
   static const String locationLogRecorded = 'location_log_recorded';
+  static const String mrXCaught = 'mr_x_caught';
 }
 
 final class RealtimeEventEnvelope {
@@ -837,6 +838,32 @@ final class TeamDeletedPayload {
     return TeamDeletedPayload(
       teamId: _readInt(json, ['teamId', 'id']),
       sessionId: _readInt(json, ['sessionId']),
+    );
+  }
+}
+
+final class MrXCaughtPayload {
+  final int sessionId;
+  final int newMrXTeamId;
+  final String newMrXTeamName;
+  final int formerMrXTeamId;
+  final String formerMrXTeamName;
+
+  const MrXCaughtPayload({
+    required this.sessionId,
+    required this.newMrXTeamId,
+    required this.newMrXTeamName,
+    required this.formerMrXTeamId,
+    required this.formerMrXTeamName,
+  });
+
+  factory MrXCaughtPayload.fromJson(Map<String, dynamic> json) {
+    return MrXCaughtPayload(
+      sessionId: _readInt(json, ['sessionId']),
+      newMrXTeamId: _readInt(json, ['newMrXTeamId']),
+      newMrXTeamName: (json['newMrXTeamName'] as String?) ?? 'Team',
+      formerMrXTeamId: _readInt(json, ['formerMrXTeamId']),
+      formerMrXTeamName: (json['formerMrXTeamName'] as String?) ?? 'Team',
     );
   }
 }

--- a/xact_frontend/lib/screens/game_screen.dart
+++ b/xact_frontend/lib/screens/game_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
 import '../api/api_service.dart';
+import '../api/models.dart';
 import 'start/start_screen.dart';
 import 'team_screen.dart';
 import 'all_chat_screen.dart';
@@ -24,6 +25,7 @@ class _GameScreenState extends State<GameScreen> {
   bool _trackingInitCancelled = false;
   bool _allowDirectPop = false;
   Timer? _trackingRetryTimer;
+  StreamSubscription<RealtimeEventEnvelope>? _realtimeEventSub;
 
   final List<Widget> _screens = const [
     TeamScreen(),
@@ -36,6 +38,7 @@ class _GameScreenState extends State<GameScreen> {
   void initState() {
     super.initState();
     unawaited(_startLocationTrackingSafely());
+    unawaited(_initRealtimeAnnouncements());
     _trackingRetryTimer = Timer.periodic(const Duration(seconds: 2), (_) {
       if (!mounted || _trackingInitCancelled) {
         return;
@@ -45,6 +48,52 @@ class _GameScreenState extends State<GameScreen> {
         unawaited(_startLocationTrackingSafely());
       }
     });
+  }
+
+  Future<void> _initRealtimeAnnouncements() async {
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    try {
+      await ApiService.instance.ensureRealtimeSessionSubscription(sessionId);
+      _realtimeEventSub = ApiService.instance.realtimeEvents.listen((event) {
+        if (event.type == RealtimeEvents.mrXCaught) {
+          _onMrXCaught(MrXCaughtPayload.fromJson(event.payload));
+        }
+      });
+    } catch (_) {
+      // Announcements are best-effort; the game keeps working without them.
+    }
+  }
+
+  void _onMrXCaught(MrXCaughtPayload payload) {
+    if (!mounted) {
+      return;
+    }
+
+    final currentTeamId = AppSession.instance.currentTeamId;
+    final String message;
+    if (currentTeamId == payload.newMrXTeamId) {
+      message = 'Your team caught Mister X — you are now Mister X!';
+    } else if (currentTeamId == payload.formerMrXTeamId) {
+      message = 'You were caught! ${payload.newMrXTeamName} is now Mister X.';
+    } else {
+      message =
+          '${payload.newMrXTeamName} caught Mister X — they are the new Mister X!';
+    }
+
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message, style: XActText.bodySm),
+          backgroundColor: XActColors.surface2,
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 4),
+        ),
+      );
   }
 
   Future<void> _startLocationTrackingSafely() async {
@@ -60,6 +109,7 @@ class _GameScreenState extends State<GameScreen> {
   void dispose() {
     _trackingInitCancelled = true;
     _trackingRetryTimer?.cancel();
+    _realtimeEventSub?.cancel();
     LocationService.instance.stopTracking();
     super.dispose();
   }

--- a/xact_frontend/lib/screens/team_screen.dart
+++ b/xact_frontend/lib/screens/team_screen.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../api/api_service.dart';
+import '../api/models.dart';
+import '../services/app_session.dart';
 import '../widgets/team/team_card.dart';
 import '../widgets/xact_branding.dart';
 
@@ -12,12 +16,164 @@ class TeamScreen extends StatefulWidget {
 }
 
 class _TeamScreenState extends State<TeamScreen> {
-  late final Future<List<TeamCardData>> _load;
+  late Future<List<TeamCardData>> _load;
+  StreamSubscription<RealtimeEventEnvelope>? _realtimeEventSub;
+  Timer? _refreshDebounce;
+  bool _markingCaught = false;
 
   @override
   void initState() {
     super.initState();
     _load = ApiService.instance.loadTeamCards();
+    _initRealtime();
+  }
+
+  @override
+  void dispose() {
+    _realtimeEventSub?.cancel();
+    _refreshDebounce?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _initRealtime() async {
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    try {
+      await ApiService.instance.ensureRealtimeSessionSubscription(sessionId);
+      _realtimeEventSub = ApiService.instance.realtimeEvents.listen((event) {
+        if (_isTeamRealtimeEvent(event.type)) {
+          _queueReload();
+        }
+      });
+    } catch (_) {
+      // Screen still shows the initial load if realtime is unavailable.
+    }
+  }
+
+  bool _isTeamRealtimeEvent(String type) {
+    // A Mr. X catch arrives as two team_updated events (the role swap); reloading
+    // on these keeps the button visibility and team labels in sync for everyone.
+    return type == RealtimeEvents.teamAdded ||
+        type == RealtimeEvents.teamUpdated ||
+        type == RealtimeEvents.teamDeleted ||
+        type == RealtimeEvents.teamMemberJoined ||
+        type == RealtimeEvents.teamMemberUpdated ||
+        type == RealtimeEvents.teamMemberLeft;
+  }
+
+  void _queueReload() {
+    _refreshDebounce?.cancel();
+    _refreshDebounce = Timer(const Duration(milliseconds: 250), () {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _load = ApiService.instance.loadTeamCards();
+      });
+    });
+  }
+
+  bool _isCurrentTeamMrX(List<TeamCardData> teams) {
+    final currentTeamId = AppSession.instance.currentTeamId;
+    if (currentTeamId == null) {
+      return false;
+    }
+    return teams.any(
+      (team) => team.teamId == currentTeamId && team.role == TeamRole.mrX,
+    );
+  }
+
+  Future<void> _showCaughtDialog(List<TeamCardData> teams) async {
+    final detectiveTeams = teams
+        .where((team) => team.role == TeamRole.detective)
+        .toList(growable: false);
+
+    if (detectiveTeams.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No detective team to hand Mister X over to.')),
+      );
+      return;
+    }
+
+    final selected = await showDialog<TeamCardData>(
+      context: context,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: XActColors.surface,
+          shape: const RoundedRectangleBorder(borderRadius: XActRadius.lg),
+          child: Padding(
+            padding: const EdgeInsets.all(XActSpace.s5),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Who caught you?', style: XActText.heading),
+                const SizedBox(height: XActSpace.s2),
+                Text(
+                  'Hand over the Mister X role to the detective team that caught you.',
+                  style: XActText.caption.copyWith(color: XActColors.text3),
+                ),
+                const SizedBox(height: XActSpace.s4),
+                for (final team in detectiveTeams) ...[
+                  XActBranding.buildActionCard(
+                    icon: Icons.groups_rounded,
+                    title: team.teamName,
+                    subtitle: '${team.members.length} player(s)',
+                    onTap: () => Navigator.pop(dialogContext, team),
+                  ),
+                  const SizedBox(height: XActSpace.s2),
+                ],
+                const SizedBox(height: XActSpace.s2),
+                XActBranding.buildCancelButton(
+                  text: 'Cancel',
+                  onPressed: () => Navigator.pop(dialogContext),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    if (selected == null) {
+      return;
+    }
+
+    await _markCaught(selected);
+  }
+
+  Future<void> _markCaught(TeamCardData catchingTeam) async {
+    if (_markingCaught) {
+      return;
+    }
+
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    setState(() => _markingCaught = true);
+    try {
+      await ApiService.instance.markMrXCaught(
+        sessionId: sessionId,
+        catchingTeamId: catchingTeam.teamId,
+      );
+      // The resulting role swap arrives via realtime team_updated events, which
+      // reload this screen (and flip the map view) automatically.
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to hand over Mister X: $error')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _markingCaught = false);
+      }
+    }
   }
 
   @override
@@ -68,32 +224,51 @@ class _TeamScreenState extends State<TeamScreen> {
               .where((team) => team.members.isNotEmpty)
               .toList(growable: false);
 
-          if (visibleTeams.isEmpty) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text(
-                  'No teams found',
-                  style: XActText.bodySm.copyWith(color: XActColors.text3),
-                ),
-              ),
-            );
-          }
+          final showCaughtButton = _isCurrentTeamMrX(teams);
 
-          return ListView.separated(
-            padding: const EdgeInsets.all(16),
-            itemCount: visibleTeams.length,
-            separatorBuilder: (context, index) => const SizedBox(height: 12),
-            itemBuilder: (context, index) {
-              final team = visibleTeams[index];
-              return TeamCard(
-                teamName: team.teamName,
-                role: team.role,
-                color: team.color,
-                members: team.members,
-                isMisterX: team.isMisterX,
-              );
-            },
+          return Column(
+            children: [
+              if (showCaughtButton)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                  child: XActBranding.buildPrimaryButton(
+                    text: _markingCaught ? 'Handing over…' : "I've been caught",
+                    icon: Icons.pan_tool_rounded,
+                    height: 52,
+                    onPressed:
+                        _markingCaught ? null : () => _showCaughtDialog(teams),
+                  ),
+                ),
+              Expanded(
+                child: visibleTeams.isEmpty
+                    ? Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: Text(
+                            'No teams found',
+                            style: XActText.bodySm
+                                .copyWith(color: XActColors.text3),
+                          ),
+                        ),
+                      )
+                    : ListView.separated(
+                        padding: const EdgeInsets.all(16),
+                        itemCount: visibleTeams.length,
+                        separatorBuilder: (context, index) =>
+                            const SizedBox(height: 12),
+                        itemBuilder: (context, index) {
+                          final team = visibleTeams[index];
+                          return TeamCard(
+                            teamName: team.teamName,
+                            role: team.role,
+                            color: team.color,
+                            members: team.members,
+                            isMisterX: team.isMisterX,
+                          );
+                        },
+                      ),
+              ),
+            ],
           );
         },
       ),

--- a/xact_frontend/lib/widgets/map_area.dart
+++ b/xact_frontend/lib/widgets/map_area.dart
@@ -132,7 +132,12 @@ class _MapAreaState extends State<MapArea> {
         if (event.type == RealtimeEvents.teamMemberJoined ||
             event.type == RealtimeEvents.teamMemberUpdated ||
             event.type == RealtimeEvents.teamMemberLeft ||
-            event.type == RealtimeEvents.locationLogRecorded) {
+            event.type == RealtimeEvents.locationLogRecorded ||
+            // A Mr. X catch swaps two teams' roles (team_updated), which changes
+            // who is visible on the map and the legend, so re-filter on these too.
+            event.type == RealtimeEvents.teamAdded ||
+            event.type == RealtimeEvents.teamUpdated ||
+            event.type == RealtimeEvents.teamDeleted) {
           _refreshPlayers();
         }
       });


### PR DESCRIPTION
Implement role swapping between Mr. X and the catching team when Mr. X is caught, allowing the game to continue. Update frontend to support real-time announcements and UI changes reflecting the new roles. Add necessary validations and error handling for catching eligibility.