### PR TITLE
Feat: added a post game analysis screen

### DIFF
--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -17,6 +17,12 @@ class EndMatchScreen extends StatefulWidget {
 
 class _EndMatchScreenState extends State<EndMatchScreen>
     with SingleTickerProviderStateMixin {
+  static const double _tabContentPaddingTop = XActSpace.s4;
+  static const double _tabContentPaddingBottom = XActSpace.s6;
+  static const double _tabSectionGap = XActSpace.s4;
+  static const double _bubbleGridGap = XActSpace.s3;
+  static const double _bubbleGridWideBreakpoint = 720;
+
   bool _loading = true;
   bool _working = false;
   GameSessionDetails? _sessionDetails;
@@ -492,31 +498,28 @@ class _EndMatchScreenState extends State<EndMatchScreen>
     return ListView(
       padding: const EdgeInsets.fromLTRB(
         XActSpace.s4,
-        XActSpace.s1,
+        _tabContentPaddingTop,
         XActSpace.s4,
-        XActSpace.s5,
+        _tabContentPaddingBottom,
       ),
       children: [
         _SectionCard(
           title: 'Result snapshot',
           subtitle: 'A compact recap using the current session data.',
-          child: Column(
+          child: _buildDetailBubbleGrid(
             children: [
               _DetailRow(
                 label: 'Winning Team',
                 value: _winnerTeamName ?? 'Not available',
               ),
-              const SizedBox(height: 12),
               _DetailRow(
                 label: 'Match Duration',
                 value: _matchDurationText ?? 'Not available',
               ),
-              const SizedBox(height: 12),
               _DetailRow(
                 label: 'Planned Duration',
                 value: '${details?.plannedDurationMinutes ?? 0} min',
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'Reveal Interval',
                 value: '${details?.mrXRevealInterval ?? 0} min',
@@ -524,19 +527,17 @@ class _EndMatchScreenState extends State<EndMatchScreen>
             ],
           ),
         ),
-        const SizedBox(height: XActSpace.s3),
+        const SizedBox(height: _tabSectionGap),
         _SectionCard(
           title: 'Status summary',
           subtitle: 'Useful end-of-match signals from the backend.',
-          child: Column(
+          child: _buildDetailBubbleGrid(
             children: [
               _DetailRow(
                 label: 'Session Status',
                 value: _sessionDetails?.status?.name ?? 'Unknown',
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(label: 'Players in Session', value: '$_playerCount'),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'Latest Location Points',
                 value: '${snapshot?.latestLocations.length ?? 0}',
@@ -566,13 +567,13 @@ class _EndMatchScreenState extends State<EndMatchScreen>
     return ListView.separated(
       padding: const EdgeInsets.fromLTRB(
         XActSpace.s4,
-        XActSpace.s1,
+        _tabContentPaddingTop,
         XActSpace.s4,
-        XActSpace.s5,
+        _tabContentPaddingBottom,
       ),
       itemCount: teams.length,
       separatorBuilder: (context, index) =>
-          const SizedBox(height: XActSpace.s3),
+          const SizedBox(height: _tabSectionGap),
       itemBuilder: (context, index) {
         final team = teams[index];
         final members = _snapshot!.membersByTeamId[team.teamId] ?? const [];
@@ -584,7 +585,9 @@ class _EndMatchScreenState extends State<EndMatchScreen>
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
+              Wrap(
+                spacing: _bubbleGridGap,
+                runSpacing: _bubbleGridGap,
                 children: [
                   _TagChip(
                     text: team.isCaught ? 'Caught' : 'Active',
@@ -592,7 +595,6 @@ class _EndMatchScreenState extends State<EndMatchScreen>
                         ? XActColors.primary
                         : XActColors.success,
                   ),
-                  const SizedBox(width: 8),
                   _TagChip(
                     text: '${members.length} players',
                     color: XActColors.secondary,
@@ -637,37 +639,33 @@ class _EndMatchScreenState extends State<EndMatchScreen>
     return ListView(
       padding: const EdgeInsets.fromLTRB(
         XActSpace.s4,
-        XActSpace.s1,
+        _tabContentPaddingTop,
         XActSpace.s4,
-        XActSpace.s5,
+        _tabContentPaddingBottom,
       ),
       children: [
         _SectionCard(
           title: 'Match timing',
           subtitle:
               'The backend only provides the session timing fields below.',
-          child: Column(
+          child: _buildDetailBubbleGrid(
             children: [
               _DetailRow(
                 label: 'Session Name',
                 value: details?.sessionName ?? 'Not available',
               ),
-              const SizedBox(height: 12),
               _DetailRow(
                 label: 'Session ID',
                 value: '${details?.sessionId ?? widget.sessionId}',
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'Start Time',
                 value: _formatDateTime(details?.startTime),
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'End Time',
                 value: _formatDateTime(details?.endTime),
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'Match Duration',
                 value: _matchDurationText ?? 'Not available',
@@ -675,27 +673,46 @@ class _EndMatchScreenState extends State<EndMatchScreen>
             ],
           ),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: _tabSectionGap),
         _SectionCard(
           title: 'Match configuration',
           subtitle: 'Useful settings already known at end of play.',
-          child: Column(
+          child: _buildDetailBubbleGrid(
             children: [
               _DetailRow(
                 label: 'Planned Duration',
                 value: '${details?.plannedDurationMinutes ?? 0} min',
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(
                 label: 'Reveal Interval',
                 value: '${details?.mrXRevealInterval ?? 0} min',
               ),
-              const SizedBox(height: XActSpace.s3),
               _DetailRow(label: 'Caught Teams', value: '$_caughtTeamCount'),
             ],
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildDetailBubbleGrid({required List<Widget> children}) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWideLayout = constraints.maxWidth >= _bubbleGridWideBreakpoint;
+        final columns = isWideLayout ? 2 : 1;
+        final itemWidth = columns == 1
+            ? constraints.maxWidth
+            : (constraints.maxWidth - _bubbleGridGap) / 2;
+
+        return Wrap(
+          spacing: _bubbleGridGap,
+          runSpacing: _bubbleGridGap,
+          children: [
+            for (final child in children)
+              SizedBox(width: itemWidth, child: child),
+          ],
+        );
+      },
     );
   }
 

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -1,0 +1,942 @@
+import 'package:flutter/material.dart';
+import 'package:xact_frontend/api/api_service.dart';
+import 'package:xact_frontend/api/models.dart';
+import 'package:xact_frontend/screens/start/start_screen.dart';
+import 'package:xact_frontend/screens/team/team_lobby.dart';
+import 'package:xact_frontend/services/app_session.dart';
+import 'package:xact_frontend/widgets/xact_branding.dart';
+
+class EndMatchScreen extends StatefulWidget {
+  final int sessionId;
+
+  const EndMatchScreen({super.key, required this.sessionId});
+
+  @override
+  State<EndMatchScreen> createState() => _EndMatchScreenState();
+}
+
+class _EndMatchScreenState extends State<EndMatchScreen>
+    with SingleTickerProviderStateMixin {
+  bool _loading = true;
+  bool _working = false;
+  GameSessionDetails? _sessionDetails;
+  LobbySnapshot? _snapshot;
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _loadSummary();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadSummary() async {
+    try {
+      final results = await Future.wait<Object?>([
+        ApiService.instance.getGameSession(widget.sessionId),
+        ApiService.instance.loadLobbySnapshot(widget.sessionId),
+      ]);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _sessionDetails = results[0] as GameSessionDetails;
+        _snapshot = results[1] as LobbySnapshot;
+        _loading = false;
+      });
+    } catch (_) {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  String? get _winnerTeamName {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return null;
+    }
+
+    final playableTeams = snapshot.teams
+        .where((team) => team.role != TeamRole.spectator)
+        .toList(growable: false);
+    if (playableTeams.isEmpty) {
+      return null;
+    }
+
+    final mrXTeam = playableTeams
+        .where((team) => team.role == TeamRole.mrX)
+        .toList(growable: false);
+    if (mrXTeam.length == 1 && !mrXTeam.first.isCaught) {
+      return mrXTeam.first.teamName;
+    }
+
+    if (playableTeams.length == 1) {
+      return playableTeams.first.teamName;
+    }
+
+    return null;
+  }
+
+  String? get _matchDurationText {
+    final details = _sessionDetails;
+    final startTime = details?.startTime;
+    final endTime = details?.endTime;
+
+    if (startTime == null || endTime == null) {
+      return null;
+    }
+
+    final duration = endTime.difference(startTime);
+    if (duration.isNegative) {
+      return null;
+    }
+
+    return _formatDuration(duration);
+  }
+
+  String get _summaryText {
+    final details = _sessionDetails;
+    final winner = _winnerTeamName;
+    final duration = _matchDurationText;
+
+    if (details?.status == SessionStatus.finished &&
+        winner != null &&
+        duration != null) {
+      return 'The match has ended with a recorded result.';
+    }
+
+    if (winner != null || duration != null) {
+      return 'Partial match summary available.';
+    }
+
+    return 'No detailed match summary is available yet.';
+  }
+
+  int get _teamCount {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return 0;
+    }
+
+    return snapshot.teams
+        .where((team) => team.role != TeamRole.spectator)
+        .length;
+  }
+
+  int get _playerCount {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return 0;
+    }
+
+    return snapshot.membersByTeamId.values.fold<int>(
+      0,
+      (sum, members) => sum + members.length,
+    );
+  }
+
+  int get _caughtTeamCount {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return 0;
+    }
+
+    return snapshot.teams
+        .where((team) => team.role != TeamRole.spectator && team.isCaught)
+        .length;
+  }
+
+  List<TeamDetails> get _playableTeams {
+    final snapshot = _snapshot;
+    if (snapshot == null) {
+      return const [];
+    }
+
+    return snapshot.teams
+        .where((team) => team.role != TeamRole.spectator)
+        .toList(growable: false);
+  }
+
+  String _formatDuration(Duration duration) {
+    final totalMinutes = duration.inMinutes;
+    final hours = totalMinutes ~/ 60;
+    final minutes = totalMinutes % 60;
+
+    if (hours > 0 && minutes > 0) {
+      return '${hours}h ${minutes}m';
+    }
+
+    if (hours > 0) {
+      return '${hours}h';
+    }
+
+    if (minutes > 0) {
+      return '${minutes}m';
+    }
+
+    return '< 1m';
+  }
+
+  String _formatDateTime(DateTime? value) {
+    if (value == null) {
+      return 'Not available';
+    }
+
+    final local = value.toLocal();
+    final day = local.day.toString().padLeft(2, '0');
+    final month = local.month.toString().padLeft(2, '0');
+    final year = local.year;
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return '$day.$month.$year $hour:$minute';
+  }
+
+  String _roleLabel(TeamRole? role) => switch (role) {
+    TeamRole.mrX => 'Mister X',
+    TeamRole.detective => 'Detective',
+    TeamRole.spectator => 'Spectator',
+    null => 'Team',
+  };
+
+  Color _roleColor(TeamRole? role) => XActColors.roleColor(role);
+
+  Future<void> _backToLobby() async {
+    setState(() => _working = true);
+    try {
+      final details =
+          _sessionDetails ??
+          await ApiService.instance.getGameSession(widget.sessionId);
+      if (!mounted) {
+        return;
+      }
+
+      final currentUserId = AppSession.instance.currentUserId;
+      await Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => GameLobbyScreen(
+            sessionId: widget.sessionId,
+            gameCode: details.joinCode,
+            gameName: details.sessionName,
+            isLeader:
+                currentUserId != null && currentUserId == details.hostUserId,
+          ),
+        ),
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not reopen lobby: $error')));
+    } finally {
+      if (mounted) {
+        setState(() => _working = false);
+      }
+    }
+  }
+
+  Future<void> _leaveLobby() async {
+    setState(() => _working = true);
+    try {
+      await ApiService.instance.closeCurrentSession();
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not leave lobby cleanly: $error')),
+        );
+      }
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    await Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const StartScreen()),
+      (route) => false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: XActColors.bg,
+      body: Stack(
+        children: [
+          Positioned.fill(child: XActBranding.aurora()),
+          SafeArea(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final contentWidth = constraints.maxWidth < 1080
+                    ? constraints.maxWidth
+                    : 1080.0;
+
+                return Center(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: contentWidth),
+                    child: Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                            XActSpace.s4,
+                            XActSpace.s3,
+                            XActSpace.s4,
+                            0,
+                          ),
+                          child: XActBranding.buildTopBar(
+                            context: context,
+                            eyebrow: 'Match result',
+                            title: 'Match beendet',
+                            showBack: false,
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(
+                            XActSpace.s4,
+                            XActSpace.s2,
+                            XActSpace.s4,
+                            XActSpace.s4,
+                          ),
+                          child: _buildHeaderCard(),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: XActSpace.s4,
+                          ),
+                          child: _buildTabBar(),
+                        ),
+                        const SizedBox(height: XActSpace.s3),
+                        Expanded(
+                          child: TabBarView(
+                            controller: _tabController,
+                            children: [
+                              _buildOverviewTab(),
+                              _buildTeamsTab(),
+                              _buildSessionTab(),
+                            ],
+                          ),
+                        ),
+                        _buildActionArea(),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeaderCard() {
+    return XActBranding.buildFormCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: XActColors.primarySoft,
+                  borderRadius: XActRadius.md,
+                  border: Border.all(color: XActColors.hairlineSoft),
+                ),
+                child: const Icon(
+                  Icons.flag_rounded,
+                  color: XActColors.primary,
+                  size: 30,
+                ),
+              ),
+              const SizedBox(width: XActSpace.s4),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Match beendet',
+                      style: XActText.displaySm.copyWith(fontSize: 30),
+                    ),
+                    const SizedBox(height: XActSpace.s1),
+                    Text(
+                      _summaryText,
+                      style: XActText.body.copyWith(color: XActColors.text2),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: XActSpace.s4),
+          if (_loading)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: XActSpace.s4),
+              child: Center(child: CircularProgressIndicator()),
+            )
+          else ...[
+            Row(
+              children: [
+                Expanded(
+                  child: _MiniStatCard(
+                    label: 'Winner',
+                    value: _winnerTeamName ?? 'Not available',
+                    accent: _roleColor(TeamRole.mrX),
+                  ),
+                ),
+                const SizedBox(width: XActSpace.s3),
+                Expanded(
+                  child: _MiniStatCard(
+                    label: 'Duration',
+                    value: _matchDurationText ?? 'Not available',
+                    accent: XActColors.secondary,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: XActSpace.s3),
+            Row(
+              children: [
+                Expanded(
+                  child: _MiniStatCard(
+                    label: 'Teams',
+                    value: '$_teamCount',
+                    accent: XActColors.success,
+                  ),
+                ),
+                const SizedBox(width: XActSpace.s3),
+                Expanded(
+                  child: _MiniStatCard(
+                    label: 'Players',
+                    value: '$_playerCount',
+                    accent: XActColors.warning,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: XActSpace.s3),
+            _DetailRow(
+              label: 'Status',
+              value: _sessionDetails?.status == SessionStatus.finished
+                  ? 'Finished'
+                  : 'Summary loaded',
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabBar() {
+    return Container(
+      padding: const EdgeInsets.all(XActSpace.s1),
+      decoration: BoxDecoration(
+        color: XActColors.surface,
+        borderRadius: XActRadius.lg,
+        border: Border.all(color: XActColors.hairlineSoft),
+        boxShadow: XActElevation.e1,
+      ),
+      child: TabBar(
+        controller: _tabController,
+        isScrollable: false,
+        indicatorSize: TabBarIndicatorSize.tab,
+        labelPadding: const EdgeInsets.symmetric(
+          horizontal: XActSpace.s3,
+          vertical: XActSpace.s2,
+        ),
+        indicatorPadding: const EdgeInsets.all(2),
+        labelColor: Colors.white,
+        unselectedLabelColor: XActColors.text3,
+        indicator: BoxDecoration(
+          borderRadius: XActRadius.md,
+          gradient: const LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [XActColors.secondaryLight, XActColors.secondaryDark],
+          ),
+        ),
+        dividerColor: Colors.transparent,
+        labelStyle: XActText.bodySm.copyWith(fontWeight: FontWeight.w700),
+        unselectedLabelStyle: XActText.bodySm.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+        tabs: const [
+          Tab(text: 'Overview'),
+          Tab(text: 'Teams'),
+          Tab(text: 'Session'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOverviewTab() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final snapshot = _snapshot;
+    final details = _sessionDetails;
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        XActSpace.s4,
+        XActSpace.s1,
+        XActSpace.s4,
+        XActSpace.s5,
+      ),
+      children: [
+        _SectionCard(
+          title: 'Result snapshot',
+          subtitle: 'A compact recap using the current session data.',
+          child: Column(
+            children: [
+              _DetailRow(
+                label: 'Winning Team',
+                value: _winnerTeamName ?? 'Not available',
+              ),
+              const SizedBox(height: 12),
+              _DetailRow(
+                label: 'Match Duration',
+                value: _matchDurationText ?? 'Not available',
+              ),
+              const SizedBox(height: 12),
+              _DetailRow(
+                label: 'Planned Duration',
+                value: '${details?.plannedDurationMinutes ?? 0} min',
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'Reveal Interval',
+                value: '${details?.mrXRevealInterval ?? 0} min',
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: XActSpace.s3),
+        _SectionCard(
+          title: 'Status summary',
+          subtitle: 'Useful end-of-match signals from the backend.',
+          child: Column(
+            children: [
+              _DetailRow(
+                label: 'Session Status',
+                value: _sessionDetails?.status?.name ?? 'Unknown',
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(label: 'Players in Session', value: '$_playerCount'),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'Latest Location Points',
+                value: '${snapshot?.latestLocations.length ?? 0}',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTeamsTab() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final teams = _playableTeams;
+    if (teams.isEmpty) {
+      return Center(
+        child: Text(
+          'No team data available',
+          style: XActText.bodySm.copyWith(color: XActColors.text3),
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(
+        XActSpace.s4,
+        XActSpace.s1,
+        XActSpace.s4,
+        XActSpace.s5,
+      ),
+      itemCount: teams.length,
+      separatorBuilder: (context, index) =>
+          const SizedBox(height: XActSpace.s3),
+      itemBuilder: (context, index) {
+        final team = teams[index];
+        final members = _snapshot!.membersByTeamId[team.teamId] ?? const [];
+
+        return _SectionCard(
+          title: team.teamName,
+          subtitle: _roleLabel(team.role),
+          leadingColor: _roleColor(team.role),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _TagChip(
+                    text: team.isCaught ? 'Caught' : 'Active',
+                    color: team.isCaught
+                        ? XActColors.primary
+                        : XActColors.success,
+                  ),
+                  const SizedBox(width: 8),
+                  _TagChip(
+                    text: '${members.length} players',
+                    color: XActColors.secondary,
+                  ),
+                ],
+              ),
+              if (members.isNotEmpty) ...[
+                const SizedBox(height: XActSpace.s3),
+                Wrap(
+                  spacing: XActSpace.s2,
+                  runSpacing: XActSpace.s2,
+                  children: [
+                    for (final member in members)
+                      _TagChip(
+                        text: _memberLabel(member),
+                        color: member.isTeamLeader
+                            ? XActColors.warning
+                            : XActColors.text4,
+                      ),
+                  ],
+                ),
+              ] else ...[
+                const SizedBox(height: XActSpace.s3),
+                Text(
+                  'No players assigned to this team.',
+                  style: XActText.caption.copyWith(color: XActColors.text4),
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSessionTab() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final details = _sessionDetails;
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        XActSpace.s4,
+        XActSpace.s1,
+        XActSpace.s4,
+        XActSpace.s5,
+      ),
+      children: [
+        _SectionCard(
+          title: 'Match timing',
+          subtitle:
+              'The backend only provides the session timing fields below.',
+          child: Column(
+            children: [
+              _DetailRow(
+                label: 'Session Name',
+                value: details?.sessionName ?? 'Not available',
+              ),
+              const SizedBox(height: 12),
+              _DetailRow(
+                label: 'Session ID',
+                value: '${details?.sessionId ?? widget.sessionId}',
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'Start Time',
+                value: _formatDateTime(details?.startTime),
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'End Time',
+                value: _formatDateTime(details?.endTime),
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'Match Duration',
+                value: _matchDurationText ?? 'Not available',
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        _SectionCard(
+          title: 'Match configuration',
+          subtitle: 'Useful settings already known at end of play.',
+          child: Column(
+            children: [
+              _DetailRow(
+                label: 'Planned Duration',
+                value: '${details?.plannedDurationMinutes ?? 0} min',
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(
+                label: 'Reveal Interval',
+                value: '${details?.mrXRevealInterval ?? 0} min',
+              ),
+              const SizedBox(height: XActSpace.s3),
+              _DetailRow(label: 'Caught Teams', value: '$_caughtTeamCount'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionArea() {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: XActColors.bg2.withValues(alpha: .96),
+        border: Border(top: BorderSide(color: XActColors.hairlineSoft)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: .35),
+            blurRadius: 24,
+            offset: const Offset(0, -8),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            XActSpace.s4,
+            XActSpace.s4,
+            XActSpace.s4,
+            XActSpace.s4,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (_working) ...[
+                const Padding(
+                  padding: EdgeInsets.only(bottom: XActSpace.s3),
+                  child: LinearProgressIndicator(
+                    minHeight: 3,
+                    backgroundColor: Colors.transparent,
+                    color: XActColors.secondary,
+                  ),
+                ),
+              ],
+              Text(
+                'Session actions',
+                style: XActText.caption.copyWith(color: XActColors.text4),
+              ),
+              const SizedBox(height: XActSpace.s2),
+              XActBranding.buildSecondaryButton(
+                text: 'Back to Lobby',
+                icon: Icons.meeting_room_rounded,
+                onPressed: _working ? null : _backToLobby,
+                height: 54,
+              ),
+              const SizedBox(height: XActSpace.s3),
+              XActBranding.buildGhostButton(
+                text: 'Leave Lobby',
+                icon: Icons.logout_rounded,
+                onPressed: _working ? null : _leaveLobby,
+                height: 54,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _memberLabel(TeamMemberDetails member) {
+    if (member.guestName != null && member.guestName!.trim().isNotEmpty) {
+      return member.guestName!.trim();
+    }
+
+    if (member.userId != null) {
+      return 'User ${member.userId}';
+    }
+
+    return 'Player ${member.memberId}';
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _DetailRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: XActColors.surface2,
+        borderRadius: XActRadius.md,
+        border: Border.all(color: XActColors.hairlineSoft),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: XActText.caption.copyWith(color: XActColors.text4),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: XActText.body.copyWith(fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniStatCard extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color accent;
+
+  const _MiniStatCard({
+    required this.label,
+    required this.value,
+    required this.accent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(minHeight: 92),
+      padding: const EdgeInsets.all(XActSpace.s4),
+      decoration: BoxDecoration(
+        color: XActColors.surface2,
+        borderRadius: XActRadius.lg,
+        border: Border.all(color: accent.withValues(alpha: .45)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            label,
+            style: XActText.caption.copyWith(color: XActColors.text4),
+          ),
+          const SizedBox(height: XActSpace.s2),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: XActText.body.copyWith(
+              fontWeight: FontWeight.w700,
+              color: accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final Widget child;
+  final Color? leadingColor;
+
+  const _SectionCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+    this.leadingColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(XActSpace.s4),
+      decoration: BoxDecoration(
+        color: XActColors.surface,
+        borderRadius: XActRadius.xl,
+        border: Border.all(color: XActColors.hairlineSoft),
+        boxShadow: XActElevation.e1,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 10,
+                height: 10,
+                margin: const EdgeInsets.only(top: 6, right: XActSpace.s2),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: leadingColor ?? XActColors.secondary,
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: XActText.heading),
+                    const SizedBox(height: XActSpace.s1),
+                    Text(
+                      subtitle,
+                      style: XActText.caption.copyWith(color: XActColors.text3),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  final String text;
+  final Color color;
+
+  const _TagChip({required this.text, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: XActSpace.s3,
+        vertical: XActSpace.s2,
+      ),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: .14),
+        borderRadius: XActRadius.pill,
+        border: Border.all(color: color.withValues(alpha: .35)),
+      ),
+      child: Text(
+        text,
+        style: XActText.caption.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/xact_frontend/lib/screens/game_screen.dart
+++ b/xact_frontend/lib/screens/game_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import '../api/api_service.dart';
 import '../api/models.dart';
+import 'end_match_screen.dart';
 import 'start/start_screen.dart';
 import 'team_screen.dart';
 import 'all_chat_screen.dart';
@@ -24,8 +25,12 @@ class _GameScreenState extends State<GameScreen> {
   bool _isMapFullscreen = false;
   bool _trackingInitCancelled = false;
   bool _allowDirectPop = false;
+  bool _endMatchNavigationStarted = false;
+  bool _endingGame = false;
   Timer? _trackingRetryTimer;
+  Timer? _sessionStatusPollTimer;
   StreamSubscription<RealtimeEventEnvelope>? _realtimeEventSub;
+  GameSessionDetails? _sessionDetails;
 
   final List<Widget> _screens = const [
     TeamScreen(),
@@ -39,6 +44,16 @@ class _GameScreenState extends State<GameScreen> {
     super.initState();
     unawaited(_startLocationTrackingSafely());
     unawaited(_initRealtimeAnnouncements());
+    unawaited(_loadSessionDetails());
+    unawaited(_checkForFinishedSession());
+    _sessionStatusPollTimer = Timer.periodic(const Duration(seconds: 4), (_) {
+      if (!mounted || _endMatchNavigationStarted) {
+        return;
+      }
+
+      unawaited(_checkForFinishedSession());
+      unawaited(_loadSessionDetails());
+    });
     _trackingRetryTimer = Timer.periodic(const Duration(seconds: 2), (_) {
       if (!mounted || _trackingInitCancelled) {
         return;
@@ -65,6 +80,24 @@ class _GameScreenState extends State<GameScreen> {
       });
     } catch (_) {
       // Announcements are best-effort; the game keeps working without them.
+    }
+  }
+
+  Future<void> _loadSessionDetails() async {
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    try {
+      final details = await ApiService.instance.getGameSession(sessionId);
+      if (!mounted) {
+        return;
+      }
+
+      setState(() => _sessionDetails = details);
+    } catch (_) {
+      // Best-effort polling; the button can remain hidden until a successful fetch.
     }
   }
 
@@ -109,9 +142,36 @@ class _GameScreenState extends State<GameScreen> {
   void dispose() {
     _trackingInitCancelled = true;
     _trackingRetryTimer?.cancel();
+    _sessionStatusPollTimer?.cancel();
     _realtimeEventSub?.cancel();
     LocationService.instance.stopTracking();
     super.dispose();
+  }
+
+  Future<void> _checkForFinishedSession() async {
+    if (_endMatchNavigationStarted || !mounted) {
+      return;
+    }
+
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    try {
+      final details = await ApiService.instance.getGameSession(sessionId);
+      if (!mounted || _endMatchNavigationStarted) {
+        return;
+      }
+
+      setState(() => _sessionDetails = details);
+
+      if (details.status == SessionStatus.finished) {
+        await _openEndMatchScreen();
+      }
+    } catch (_) {
+      // Best-effort poll; transient failures should not interrupt play.
+    }
   }
 
   Future<void> _startLocationTracking() async {
@@ -220,6 +280,66 @@ class _GameScreenState extends State<GameScreen> {
     }
   }
 
+  Future<void> _openEndMatchScreen() async {
+    if (_endMatchNavigationStarted || !mounted) {
+      return;
+    }
+
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null) {
+      return;
+    }
+
+    _endMatchNavigationStarted = true;
+    _trackingInitCancelled = true;
+    _trackingRetryTimer?.cancel();
+    _sessionStatusPollTimer?.cancel();
+    _realtimeEventSub?.cancel();
+
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) {
+      return;
+    }
+
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => EndMatchScreen(sessionId: sessionId)),
+    );
+  }
+
+  bool get _isHost {
+    final details = _sessionDetails;
+    final currentUserId = AppSession.instance.currentUserId;
+    return details != null &&
+        currentUserId != null &&
+        details.hostUserId == currentUserId;
+  }
+
+  Future<void> _endGameAsHost() async {
+    final sessionId = AppSession.instance.currentSessionId;
+    if (sessionId == null || _endingGame) {
+      return;
+    }
+
+    setState(() => _endingGame = true);
+    try {
+      await ApiService.instance.endGameSession(sessionId);
+      await _openEndMatchScreen();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to end game session: $error');
+      debugPrintStack(stackTrace: stackTrace);
+
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Could not end game: $error')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _endingGame = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return PopScope(
@@ -241,12 +361,12 @@ class _GameScreenState extends State<GameScreen> {
                   ],
                 ),
               ),
-        bottomNavigationBar: _isMapFullscreen ? null : _buildBottomNav(),
+        bottomNavigationBar: _isMapFullscreen ? null : _buildBottomBar(),
       ),
     );
   }
 
-  Widget _buildBottomNav() {
+  Widget _buildBottomBar() {
     const items = [
       (Icons.groups_rounded, 'Team'),
       (Icons.forum_rounded, 'All Chat'),
@@ -254,28 +374,42 @@ class _GameScreenState extends State<GameScreen> {
       (Icons.flag_rounded, 'Report'),
     ];
 
-    return Container(
-      decoration: BoxDecoration(
-        color: XActColors.bg,
-        border: Border(
-          top: BorderSide(color: XActColors.hairlineSoft),
-        ),
-      ),
-      padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
-      child: SafeArea(
-        top: false,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: [
-            for (int i = 0; i < items.length; i++)
-              _buildNavItem(
-                icon: items[i].$1,
-                label: items[i].$2,
-                active: _selectedIndex == i,
-                onTap: () => setState(() => _selectedIndex = i),
+    return SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_isHost && !_endMatchNavigationStarted) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 10, 16, 8),
+              child: XActBranding.buildPrimaryButton(
+                text: _endingGame ? 'Ending game…' : 'End Game',
+                icon: Icons.stop_circle_rounded,
+                height: 52,
+                onPressed: _endingGame ? null : _endGameAsHost,
               ),
+            ),
           ],
-        ),
+          Container(
+            decoration: BoxDecoration(
+              color: XActColors.bg,
+              border: Border(top: BorderSide(color: XActColors.hairlineSoft)),
+            ),
+            padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                for (int i = 0; i < items.length; i++)
+                  _buildNavItem(
+                    icon: items[i].$1,
+                    label: items[i].$2,
+                    active: _selectedIndex == i,
+                    onTap: () => setState(() => _selectedIndex = i),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/xact_frontend/pubspec.lock
+++ b/xact_frontend/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -356,18 +356,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   message_pack_dart:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: sse
-      sha256: a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302
+      sha256: fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.1.8"
   sse_channel:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   tuple:
     dependency: transitive
     description:
@@ -838,5 +838,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.4"


### PR DESCRIPTION
Added a dedicated post-game analysis flow for finished sessions. The game screen now detects when a match ends, routes players to a new end-match screen, and lets the host end the game manually from the in-match UI.

The screen shows a match result header, an overview with the winning team, match duration, team and player counts, a teams view with each team’s status and members, and a session view with timing and configuration details. It also includes actions to return to the lobby or leave the session.