### PR TITLE
Add back-to-lobby rematch feature

### DIFF
--- a/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
+++ b/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
@@ -17,6 +17,7 @@ public interface IGameSessionRealtimePublisher
     public ValueTask PublishTeamMemberUpdatedAsync(TeamMember member);
     public ValueTask PublishTeamMemberLeftAsync(int sessionId, int teamId, int memberId, int? userId, string? guestName, Instant leftAt);
     public ValueTask PublishGameSessionStartedAsync(GameSession gameSession);
+    public ValueTask PublishGameSessionEndedAsync(GameSession gameSession);
     public ValueTask PublishLocationLogRecordedAsync(int sessionId, int teamId, LocationLog log);
     public ValueTask PublishMrXCaughtAsync(Team newMrXTeam, Team formerMrXTeam);
     public ValueTask PublishChatMessageAsync(ChatMessage message);

--- a/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
+++ b/backend/XActBackend.Core/Realtime/GameSessionSnapshotService.cs
@@ -20,6 +20,7 @@ public interface IGameSessionRealtimePublisher
     public ValueTask PublishLocationLogRecordedAsync(int sessionId, int teamId, LocationLog log);
     public ValueTask PublishMrXCaughtAsync(Team newMrXTeam, Team formerMrXTeam);
     public ValueTask PublishChatMessageAsync(ChatMessage message);
+    public ValueTask PublishRematchCreatedAsync(int finishedSessionId, GameSession newSession);
 }
 
 internal sealed class GameSessionSnapshotService(

--- a/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
+++ b/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
@@ -17,6 +17,7 @@ public static class RealtimeEvents
     public const string TeamMemberUpdated = "team_member_updated";
     public const string TeamMemberLeft = "team_member_left";
     public const string GameSessionStarted = "game_session_started";
+    public const string GameSessionEnded = "game_session_ended";
     public const string LocationLogRecorded = "location_log_recorded";
     public const string MrXCaught = "mr_x_caught";
     public const string ChatMessagePosted = "chat_message_posted";
@@ -140,6 +141,13 @@ public sealed record TeamMemberLeftPayload(
 );
 
 public sealed record GameSessionStartedPayload(
+    int SessionId,
+    SessionStatus Status,
+    Instant? StartTime,
+    Instant? EndTime
+);
+
+public sealed record GameSessionEndedPayload(
     int SessionId,
     SessionStatus Status,
     Instant? StartTime,

--- a/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
+++ b/backend/XActBackend.Core/Realtime/RealtimeContracts.cs
@@ -20,6 +20,7 @@ public static class RealtimeEvents
     public const string LocationLogRecorded = "location_log_recorded";
     public const string MrXCaught = "mr_x_caught";
     public const string ChatMessagePosted = "chat_message_posted";
+    public const string RematchCreated = "rematch_created";
 }
 
 public static class RealtimeGroups
@@ -175,4 +176,12 @@ public sealed record ChatMessagePostedPayload(
     string SenderName,
     string Content,
     Instant SentAt
+);
+
+public sealed record RematchCreatedPayload(
+    int FinishedSessionId,
+    int NewSessionId,
+    string NewJoinCode,
+    string SessionName,
+    int HostUserId
 );

--- a/backend/XActBackend.Core/Services/DomainError.cs
+++ b/backend/XActBackend.Core/Services/DomainError.cs
@@ -10,6 +10,7 @@ public static class DomainErrorCodes
     public const string InvalidSessionTransition = "invalid_session_transition";
     public const string SessionNotJoinable = "session_not_joinable";
     public const string SessionNotActive = "session_not_active";
+    public const string SessionNotFinished = "session_not_finished";
     public const string MrXTeamAlreadyExists = "mr_x_team_already_exists";
     public const string CatchingTeamNotEligible = "catching_team_not_eligible";
     public const string TeamHasMembers = "team_has_members";
@@ -45,6 +46,10 @@ public sealed record DomainError(string Code, string Message)
     public static DomainError SessionNotActive(int sessionId, SessionStatus status) =>
         new(DomainErrorCodes.SessionNotActive,
             $"Session {sessionId} is in status {status} and does not accept gameplay events.");
+
+    public static DomainError SessionNotFinished(int sessionId, SessionStatus status) =>
+        new(DomainErrorCodes.SessionNotFinished,
+            $"Session {sessionId} is in status {status} and cannot be used for a rematch until it has finished.");
 
     public static DomainError MrXTeamAlreadyExists(int sessionId) =>
         new(DomainErrorCodes.MrXTeamAlreadyExists, $"Session {sessionId} already has an Mr.X team.");

--- a/backend/XActBackend.Core/Services/GameSessionService.cs
+++ b/backend/XActBackend.Core/Services/GameSessionService.cs
@@ -81,6 +81,15 @@ public interface IGameSessionService
     public ValueTask<OneOf<MrXCaughtResult, NotFound, DomainError>> CatchMrXAsync(int sessionId, int catchingTeamId);
 
     /// <summary>
+    ///     Create a fresh waiting session that copies the teams, members, geofence area and
+    ///     settings of a finished session. The finished session is left untouched as history.
+    /// </summary>
+    /// <param name="finishedSessionId">The id of the finished session to base the rematch on</param>
+    /// <param name="newJoinCode">The unique join code to assign to the new session</param>
+    /// <returns>The newly created waiting session, or an error if the rematch could not be created</returns>
+    public ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode);
+
+    /// <summary>
     ///     Data used to create or update a game session.
     /// </summary>
     /// <param name="HostUserId">The id of the host user</param>
@@ -406,6 +415,131 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
             mrXTeam.Id);
 
         return new IGameSessionService.MrXCaughtResult(catchingTeam, mrXTeam);
+    }
+
+    public async ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode)
+    {
+        try
+        {
+            var finishedSession = await uow.GameSessionRepository.GetSessionByIdAsync(finishedSessionId, tracking: false);
+            if (finishedSession is null)
+            {
+                return new NotFound();
+            }
+
+            if (finishedSession.Status != SessionStatus.Finished)
+            {
+                logger.LogWarning(
+                    "Rejected rematch for session {SessionId} because current status {Status} is not finished",
+                    finishedSessionId,
+                    finishedSession.Status);
+                return DomainError.SessionNotFinished(finishedSessionId, finishedSession.Status);
+            }
+
+            var existingActiveSession = await uow.GameSessionRepository.GetActiveSessionByHostUserIdAsync(finishedSession.HostUserId, tracking: false);
+            if (existingActiveSession is not null)
+            {
+                logger.LogWarning(
+                    "Rejected rematch for host user {HostUserId} because session {ExistingSessionId} is still open",
+                    finishedSession.HostUserId,
+                    existingActiveSession.Id);
+                return DomainError.HostUserAlreadyHasActiveSession(finishedSession.HostUserId);
+            }
+
+            var sessionWithJoinCode = await uow.GameSessionRepository.GetSessionByJoinCodeAsync(newJoinCode, tracking: false);
+            if (sessionWithJoinCode is not null)
+            {
+                logger.LogWarning("Rejected rematch because join code {JoinCode} is already in use", newJoinCode);
+                return DomainError.JoinCodeInUse(newJoinCode);
+            }
+
+            var sourceTeams = await uow.TeamRepository.GetTeamsBySessionIdAsync(finishedSessionId, tracking: false);
+            var sourceMembers = await uow.TeamMemberRepository.GetMembersBySessionIdAsync(finishedSessionId, tracking: false);
+            var sourceGeofencePoints = await uow.GeofencePointRepository.GetPointsBySessionIdAsync(finishedSessionId, tracking: false);
+
+            var rematchSession = uow.GameSessionRepository.AddGameSession(
+                finishedSession.HostUserId,
+                finishedSession.SessionName,
+                newJoinCode,
+                finishedSession.PlannedDurationMinutes,
+                finishedSession.MrXRevealInterval
+            );
+
+            await uow.SaveChangesAsync();
+
+            logger.LogInformation(
+                "Created rematch session {RematchSessionId} from finished session {FinishedSessionId}",
+                rematchSession.Id,
+                finishedSessionId);
+
+            // Recreate the teams; their ids change, so map old->new to reattach members. Team.IsCaught
+            // defaults to false on creation, so the finished match's caught state is intentionally dropped.
+            var newTeamIdByOldTeamId = new Dictionary<int, int>();
+            var copiedTeams = new List<(int OldTeamId, Team NewTeam)>();
+            foreach (var sourceTeam in sourceTeams)
+            {
+                var newTeam = uow.TeamRepository.AddTeam(
+                    rematchSession.Id,
+                    sourceTeam.TeamName,
+                    sourceTeam.Role,
+                    sourceTeam.ColorCode,
+                    sourceTeam.MaxPlayerCount
+                );
+
+                copiedTeams.Add((sourceTeam.Id, newTeam));
+            }
+
+            await uow.SaveChangesAsync();
+
+            foreach (var (oldTeamId, newTeam) in copiedTeams)
+            {
+                newTeamIdByOldTeamId[oldTeamId] = newTeam.Id;
+            }
+
+            // Re-add every member into the matching new team. Live-position fields (CurrentLatitude,
+            // CurrentLongitude, LastUpdated) reset to null because AddTeamMember does not copy them.
+            foreach (var sourceMember in sourceMembers)
+            {
+                if (!newTeamIdByOldTeamId.TryGetValue(sourceMember.TeamId, out var newTeamId))
+                {
+                    continue;
+                }
+
+                uow.TeamMemberRepository.AddTeamMember(
+                    rematchSession.Id,
+                    newTeamId,
+                    sourceMember.UserId,
+                    sourceMember.GuestName,
+                    sourceMember.IsTeamLeader
+                );
+            }
+
+            foreach (var sourcePoint in sourceGeofencePoints)
+            {
+                uow.GeofencePointRepository.AddGeofencePoint(
+                    rematchSession.Id,
+                    sourcePoint.Latitude,
+                    sourcePoint.Longitude,
+                    sourcePoint.SequenceOrder
+                );
+            }
+
+            await uow.SaveChangesAsync();
+
+            logger.LogInformation(
+                "Copied {TeamCount} teams, {MemberCount} members and {GeofenceCount} geofence points into rematch session {RematchSessionId}",
+                sourceTeams.Count,
+                sourceMembers.Count,
+                sourceGeofencePoints.Count,
+                rematchSession.Id);
+
+            return rematchSession;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to create rematch session from finished session {FinishedSessionId}", finishedSessionId);
+            throw;
+        }
     }
 
     private static bool IsValidStatusTransition(SessionStatus currentStatus, SessionStatus requestedStatus) =>

--- a/backend/XActBackend.Core/Services/GameSessionService.cs
+++ b/backend/XActBackend.Core/Services/GameSessionService.cs
@@ -86,8 +86,13 @@ public interface IGameSessionService
     /// </summary>
     /// <param name="finishedSessionId">The id of the finished session to base the rematch on</param>
     /// <param name="newJoinCode">The unique join code to assign to the new session</param>
+    /// <param name="activeMemberIds">
+    ///     The team-member ids still connected to the finished session. When this set is non-empty,
+    ///     only those members are copied into the rematch so players who already left are not carried
+    ///     over as ghosts. A null or empty set means presence is unknown, so every member is copied.
+    /// </param>
     /// <returns>The newly created waiting session, or an error if the rematch could not be created</returns>
-    public ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode);
+    public ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode, IReadOnlySet<int>? activeMemberIds = null);
 
     /// <summary>
     ///     Data used to create or update a game session.
@@ -417,7 +422,7 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
         return new IGameSessionService.MrXCaughtResult(catchingTeam, mrXTeam);
     }
 
-    public async ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode)
+    public async ValueTask<OneOf<GameSession, NotFound, DomainError>> CreateRematchSessionAsync(int finishedSessionId, string newJoinCode, IReadOnlySet<int>? activeMemberIds = null)
     {
         try
         {
@@ -496,10 +501,20 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
                 newTeamIdByOldTeamId[oldTeamId] = newTeam.Id;
             }
 
-            // Re-add every member into the matching new team. Live-position fields (CurrentLatitude,
-            // CurrentLongitude, LastUpdated) reset to null because AddTeamMember does not copy them.
+            // Re-add every still-present member into the matching new team. Live-position fields
+            // (CurrentLatitude, CurrentLongitude, LastUpdated) reset to null because AddTeamMember does
+            // not copy them. Members who already left the finished session (no live realtime
+            // connection) are skipped so they do not linger in the new lobby as ghosts. An empty/null
+            // presence set means we have no presence info, so every member is copied as a fallback.
+            var filterByPresence = activeMemberIds is { Count: > 0 };
+            var copiedMemberCount = 0;
             foreach (var sourceMember in sourceMembers)
             {
+                if (filterByPresence && !activeMemberIds!.Contains(sourceMember.Id))
+                {
+                    continue;
+                }
+
                 if (!newTeamIdByOldTeamId.TryGetValue(sourceMember.TeamId, out var newTeamId))
                 {
                     continue;
@@ -512,6 +527,8 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
                     sourceMember.GuestName,
                     sourceMember.IsTeamLeader
                 );
+
+                copiedMemberCount++;
             }
 
             foreach (var sourcePoint in sourceGeofencePoints)
@@ -527,8 +544,9 @@ internal sealed class GameSessionService(IUnitOfWork uow, IClock clock, ILogger<
             await uow.SaveChangesAsync();
 
             logger.LogInformation(
-                "Copied {TeamCount} teams, {MemberCount} members and {GeofenceCount} geofence points into rematch session {RematchSessionId}",
+                "Copied {TeamCount} teams, {MemberCount}/{SourceMemberCount} members and {GeofenceCount} geofence points into rematch session {RematchSessionId}",
                 sourceTeams.Count,
+                copiedMemberCount,
                 sourceMembers.Count,
                 sourceGeofencePoints.Count,
                 rematchSession.Id);

--- a/backend/XActBackend.Test/GameSessionServiceTests.cs
+++ b/backend/XActBackend.Test/GameSessionServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class GameSessionServiceTests
     private readonly IUserRepository _userRepository;
     private readonly ITeamRepository _teamRepository;
     private readonly ITeamMemberRepository _teamMemberRepository;
+    private readonly IGeofencePointRepository _geofencePointRepository;
     private readonly GameSessionService _sut;
     private readonly IUnitOfWork _uow;
     private readonly IClock _clock;
@@ -43,6 +44,9 @@ public sealed class GameSessionServiceTests
 
         _teamMemberRepository = Substitute.For<ITeamMemberRepository>();
         _uow.TeamMemberRepository.Returns(_teamMemberRepository);
+
+        _geofencePointRepository = Substitute.For<IGeofencePointRepository>();
+        _uow.GeofencePointRepository.Returns(_geofencePointRepository);
 
         _clock = Substitute.For<IClock>();
         var logger = Substitute.For<ILogger<GameSessionService>>();
@@ -86,6 +90,56 @@ public sealed class GameSessionServiceTests
             TeamName = name,
             Role = role,
             ColorCode = colorCode,
+        };
+
+    private static Team CreateTeamWithMaxPlayers(
+        int id,
+        string name,
+        TeamRole role,
+        string colorCode,
+        int maxPlayerCount,
+        bool isCaught = false
+    ) =>
+        new()
+        {
+            Id = id,
+            TeamName = name,
+            Role = role,
+            ColorCode = colorCode,
+            MaxPlayerCount = maxPlayerCount,
+            IsCaught = isCaught,
+        };
+
+    private static TeamMember CreateMember(
+        int id,
+        int teamId,
+        int? userId,
+        string? guestName,
+        bool isTeamLeader
+    ) =>
+        new()
+        {
+            Id = id,
+            TeamId = teamId,
+            UserId = userId,
+            GuestName = guestName,
+            IsTeamLeader = isTeamLeader,
+        };
+
+    private static GeofencePoint CreateGeofencePoint(
+        int id,
+        int sessionId,
+        double latitude,
+        double longitude,
+        int sequenceOrder
+    ) =>
+        new()
+        {
+            Id = id,
+            SessionId = sessionId,
+            Latitude = latitude,
+            Longitude = longitude,
+            SequenceOrder = sequenceOrder,
         };
 
     [Fact]
@@ -214,6 +268,157 @@ public sealed class GameSessionServiceTests
             _ => Assert.Fail("Expected DomainError but got NotFound"),
             domainError => domainError.Code.Should().Be(DomainErrorCodes.JoinCodeInUse)
         );
+    }
+
+    [Fact]
+    public async ValueTask CreateRematchSessionAsync_ReturnsNotFound_WhenSessionMissing()
+    {
+        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns((GameSession?) null);
+
+        OneOf<GameSession, NotFound, DomainError> result = await _sut.CreateRematchSessionAsync(DefaultSessionId, "REM123");
+
+        result.Switch(
+            _ => Assert.Fail("Expected NotFound but got GameSession"),
+            _ => { /* expected */ },
+            _ => Assert.Fail("Expected NotFound but got DomainError")
+        );
+    }
+
+    [Fact]
+    public async ValueTask CreateRematchSessionAsync_ReturnsDomainError_WhenSessionNotFinished()
+    {
+        var session = CreateSession();
+        session.Status = SessionStatus.Active;
+        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
+
+        OneOf<GameSession, NotFound, DomainError> result = await _sut.CreateRematchSessionAsync(DefaultSessionId, "REM123");
+
+        result.Switch(
+            _ => Assert.Fail("Expected DomainError but got GameSession"),
+            _ => Assert.Fail("Expected DomainError but got NotFound"),
+            domainError => domainError.Code.Should().Be(DomainErrorCodes.SessionNotFinished)
+        );
+    }
+
+    [Fact]
+    public async ValueTask CreateRematchSessionAsync_ReturnsDomainError_WhenHostAlreadyHasActiveSession()
+    {
+        var session = CreateSession();
+        session.Status = SessionStatus.Finished;
+        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
+        _gameSessionRepository.GetActiveSessionByHostUserIdAsync(session.HostUserId, false)
+            .Returns(CreateSession(99, "Existing", "EXIST1"));
+
+        OneOf<GameSession, NotFound, DomainError> result = await _sut.CreateRematchSessionAsync(DefaultSessionId, "REM123");
+
+        result.Switch(
+            _ => Assert.Fail("Expected DomainError but got GameSession"),
+            _ => Assert.Fail("Expected DomainError but got NotFound"),
+            domainError => domainError.Code.Should().Be(DomainErrorCodes.HostUserAlreadyHasActiveSession)
+        );
+    }
+
+    [Fact]
+    public async ValueTask CreateRematchSessionAsync_ReturnsDomainError_WhenJoinCodeInUse()
+    {
+        var session = CreateSession();
+        session.Status = SessionStatus.Finished;
+        _gameSessionRepository.GetSessionByIdAsync(DefaultSessionId, false).Returns(session);
+        _gameSessionRepository.GetActiveSessionByHostUserIdAsync(session.HostUserId, false).Returns((GameSession?) null);
+        _gameSessionRepository.GetSessionByJoinCodeAsync("REM123", false).Returns(CreateSession(2, "Other", "REM123"));
+
+        OneOf<GameSession, NotFound, DomainError> result = await _sut.CreateRematchSessionAsync(DefaultSessionId, "REM123");
+
+        result.Switch(
+            _ => Assert.Fail("Expected DomainError but got GameSession"),
+            _ => Assert.Fail("Expected DomainError but got NotFound"),
+            domainError => domainError.Code.Should().Be(DomainErrorCodes.JoinCodeInUse)
+        );
+    }
+
+    [Fact]
+    public async ValueTask CreateRematchSessionAsync_CopiesTeamsMembersAndGeofence_WhenValid()
+    {
+        const int finishedSessionId = 5;
+        const int rematchSessionId = 6;
+        const string newJoinCode = "REM123";
+        const int hostUserId = 7;
+
+        var finishedSession = new GameSession
+        {
+            Id = finishedSessionId,
+            HostUserId = hostUserId,
+            SessionName = "Chase Night",
+            JoinCode = DefaultJoinCode,
+            Status = SessionStatus.Finished,
+            PlannedDurationMinutes = 45,
+            MrXRevealInterval = 3,
+        };
+
+        // The MrX team is flagged caught at the end of the finished match; the copy must drop that.
+        var mrXTeam = CreateTeamWithMaxPlayers(20, "Team 1", TeamRole.MrX, "#000000", 6, isCaught: true);
+        var detectiveTeam = CreateTeamWithMaxPlayers(21, "Team 2", TeamRole.Detective, "#5B7CFA", 5);
+        var sourceTeams = new List<Team> { mrXTeam, detectiveTeam };
+
+        var mrXMember = CreateMember(30, mrXTeam.Id, hostUserId, null, isTeamLeader: true);
+        var detectiveMember = CreateMember(31, detectiveTeam.Id, 8, null, isTeamLeader: true);
+        var guestMember = CreateMember(32, detectiveTeam.Id, null, "Guest A", isTeamLeader: false);
+        var sourceMembers = new List<TeamMember> { mrXMember, detectiveMember, guestMember };
+
+        var geofencePoints = new List<GeofencePoint>
+        {
+            CreateGeofencePoint(40, finishedSessionId, 48.1, 14.3, 0),
+            CreateGeofencePoint(41, finishedSessionId, 48.2, 14.4, 1),
+        };
+
+        var rematchSession = new GameSession
+        {
+            Id = rematchSessionId,
+            HostUserId = hostUserId,
+            SessionName = finishedSession.SessionName,
+            JoinCode = newJoinCode,
+            Status = SessionStatus.Waiting,
+            PlannedDurationMinutes = finishedSession.PlannedDurationMinutes,
+            MrXRevealInterval = finishedSession.MrXRevealInterval,
+        };
+
+        var newMrXTeam = CreateTeamWithMaxPlayers(120, mrXTeam.TeamName, mrXTeam.Role, mrXTeam.ColorCode, mrXTeam.MaxPlayerCount);
+        var newDetectiveTeam = CreateTeamWithMaxPlayers(121, detectiveTeam.TeamName, detectiveTeam.Role, detectiveTeam.ColorCode, detectiveTeam.MaxPlayerCount);
+
+        _gameSessionRepository.GetSessionByIdAsync(finishedSessionId, false).Returns(finishedSession);
+        _gameSessionRepository.GetActiveSessionByHostUserIdAsync(hostUserId, false).Returns((GameSession?) null);
+        _gameSessionRepository.GetSessionByJoinCodeAsync(newJoinCode, false).Returns((GameSession?) null);
+        _teamRepository.GetTeamsBySessionIdAsync(finishedSessionId, false).Returns(sourceTeams);
+        _teamMemberRepository.GetMembersBySessionIdAsync(finishedSessionId, false).Returns(sourceMembers);
+        _geofencePointRepository.GetPointsBySessionIdAsync(finishedSessionId, false).Returns(geofencePoints);
+
+        _gameSessionRepository.AddGameSession(hostUserId, finishedSession.SessionName, newJoinCode, 45, 3).Returns(rematchSession);
+        _teamRepository.AddTeam(rematchSessionId, mrXTeam.TeamName, mrXTeam.Role, mrXTeam.ColorCode, mrXTeam.MaxPlayerCount).Returns(newMrXTeam);
+        _teamRepository.AddTeam(rematchSessionId, detectiveTeam.TeamName, detectiveTeam.Role, detectiveTeam.ColorCode, detectiveTeam.MaxPlayerCount).Returns(newDetectiveTeam);
+
+        OneOf<GameSession, NotFound, DomainError> result = await _sut.CreateRematchSessionAsync(finishedSessionId, newJoinCode);
+
+        result.Switch(
+            added => added.Should().BeSameAs(rematchSession),
+            _ => Assert.Fail("Expected GameSession but got NotFound"),
+            _ => Assert.Fail("Expected GameSession but got DomainError")
+        );
+
+        // Teams copied into the new session (IsCaught reset is guaranteed by AddTeam, which always
+        // creates teams with IsCaught = false).
+        _teamRepository.Received(1).AddTeam(rematchSessionId, mrXTeam.TeamName, mrXTeam.Role, mrXTeam.ColorCode, mrXTeam.MaxPlayerCount);
+        _teamRepository.Received(1).AddTeam(rematchSessionId, detectiveTeam.TeamName, detectiveTeam.Role, detectiveTeam.ColorCode, detectiveTeam.MaxPlayerCount);
+
+        // Members re-added into the matching new team (host on new MrX team, two on new detective team).
+        _teamMemberRepository.Received(1).AddTeamMember(rematchSessionId, newMrXTeam.Id, hostUserId, null, true);
+        _teamMemberRepository.Received(1).AddTeamMember(rematchSessionId, newDetectiveTeam.Id, 8, null, true);
+        _teamMemberRepository.Received(1).AddTeamMember(rematchSessionId, newDetectiveTeam.Id, null, "Guest A", false);
+
+        // Geofence area copied point-by-point.
+        _geofencePointRepository.Received(1).AddGeofencePoint(rematchSessionId, 48.1, 14.3, 0);
+        _geofencePointRepository.Received(1).AddGeofencePoint(rematchSessionId, 48.2, 14.4, 1);
+
+        await _uow.Received(3).SaveChangesAsync();
     }
 
     [Fact]

--- a/backend/XActBackend.Test/GameSessionServiceTests.cs
+++ b/backend/XActBackend.Test/GameSessionServiceTests.cs
@@ -422,6 +422,80 @@ public sealed class GameSessionServiceTests
     }
 
     [Fact]
+    public async ValueTask CreateRematchSessionAsync_SkipsMembersThatLeft_WhenPresenceProvided()
+    {
+        const int finishedSessionId = 5;
+        const int rematchSessionId = 6;
+        const string newJoinCode = "REM123";
+        const int hostUserId = 7;
+
+        var finishedSession = new GameSession
+        {
+            Id = finishedSessionId,
+            HostUserId = hostUserId,
+            SessionName = "Chase Night",
+            JoinCode = DefaultJoinCode,
+            Status = SessionStatus.Finished,
+            PlannedDurationMinutes = 45,
+            MrXRevealInterval = 3,
+        };
+
+        var mrXTeam = CreateTeamWithMaxPlayers(20, "Team 1", TeamRole.MrX, "#000000", 6);
+        var detectiveTeam = CreateTeamWithMaxPlayers(21, "Team 2", TeamRole.Detective, "#5B7CFA", 5);
+        var sourceTeams = new List<Team> { mrXTeam, detectiveTeam };
+
+        var mrXMember = CreateMember(30, mrXTeam.Id, hostUserId, null, isTeamLeader: true);
+        var detectiveMember = CreateMember(31, detectiveTeam.Id, 8, null, isTeamLeader: true);
+        // Guest 32 has already left the finished session: it is absent from the connected set below.
+        var guestMember = CreateMember(32, detectiveTeam.Id, null, "Guest A", isTeamLeader: false);
+        var sourceMembers = new List<TeamMember> { mrXMember, detectiveMember, guestMember };
+
+        var rematchSession = new GameSession
+        {
+            Id = rematchSessionId,
+            HostUserId = hostUserId,
+            SessionName = finishedSession.SessionName,
+            JoinCode = newJoinCode,
+            Status = SessionStatus.Waiting,
+            PlannedDurationMinutes = finishedSession.PlannedDurationMinutes,
+            MrXRevealInterval = finishedSession.MrXRevealInterval,
+        };
+
+        var newMrXTeam = CreateTeamWithMaxPlayers(120, mrXTeam.TeamName, mrXTeam.Role, mrXTeam.ColorCode, mrXTeam.MaxPlayerCount);
+        var newDetectiveTeam = CreateTeamWithMaxPlayers(121, detectiveTeam.TeamName, detectiveTeam.Role, detectiveTeam.ColorCode, detectiveTeam.MaxPlayerCount);
+
+        _gameSessionRepository.GetSessionByIdAsync(finishedSessionId, false).Returns(finishedSession);
+        _gameSessionRepository.GetActiveSessionByHostUserIdAsync(hostUserId, false).Returns((GameSession?) null);
+        _gameSessionRepository.GetSessionByJoinCodeAsync(newJoinCode, false).Returns((GameSession?) null);
+        _teamRepository.GetTeamsBySessionIdAsync(finishedSessionId, false).Returns(sourceTeams);
+        _teamMemberRepository.GetMembersBySessionIdAsync(finishedSessionId, false).Returns(sourceMembers);
+        _geofencePointRepository.GetPointsBySessionIdAsync(finishedSessionId, false).Returns(new List<GeofencePoint>());
+
+        _gameSessionRepository.AddGameSession(hostUserId, finishedSession.SessionName, newJoinCode, 45, 3).Returns(rematchSession);
+        _teamRepository.AddTeam(rematchSessionId, mrXTeam.TeamName, mrXTeam.Role, mrXTeam.ColorCode, mrXTeam.MaxPlayerCount).Returns(newMrXTeam);
+        _teamRepository.AddTeam(rematchSessionId, detectiveTeam.TeamName, detectiveTeam.Role, detectiveTeam.ColorCode, detectiveTeam.MaxPlayerCount).Returns(newDetectiveTeam);
+
+        // Only the host and the detective leader are still connected; the guest has left.
+        IReadOnlySet<int> connectedMemberIds = new HashSet<int> { mrXMember.Id, detectiveMember.Id };
+
+        OneOf<GameSession, NotFound, DomainError> result =
+            await _sut.CreateRematchSessionAsync(finishedSessionId, newJoinCode, connectedMemberIds);
+
+        result.Switch(
+            added => added.Should().BeSameAs(rematchSession),
+            _ => Assert.Fail("Expected GameSession but got NotFound"),
+            _ => Assert.Fail("Expected GameSession but got DomainError")
+        );
+
+        // The two still-connected members are copied into the new lobby.
+        _teamMemberRepository.Received(1).AddTeamMember(rematchSessionId, newMrXTeam.Id, hostUserId, null, true);
+        _teamMemberRepository.Received(1).AddTeamMember(rematchSessionId, newDetectiveTeam.Id, 8, null, true);
+
+        // The guest that left is not carried over as a ghost.
+        _teamMemberRepository.DidNotReceive().AddTeamMember(rematchSessionId, newDetectiveTeam.Id, null, "Guest A", false);
+    }
+
+    [Fact]
     public async ValueTask UpdateGameSessionAsync_ReturnsNotFound_WhenSessionMissing()
     {
         var data = new IGameSessionService.GameSessionData(DefaultUserId, "Updated", "UPD123");

--- a/backend/XActBackend.TestInt/GameSessionControllerTests.cs
+++ b/backend/XActBackend.TestInt/GameSessionControllerTests.cs
@@ -223,6 +223,80 @@ public sealed class GameSessionControllerTests(WebApiTestFixture fixture) : Seed
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
+    // --- RematchGameSession ---
+
+    private ValueTask FinishSeededSessionAsync() =>
+        ModifyDatabaseContentAsync(context =>
+        {
+            GameSession session = context.GameSessions.Single(s => s.Id == SeedData.SessionId);
+            session.Status = SessionStatus.Finished;
+            session.EndTime = SeedData.BaseInstant.Plus(Duration.FromHours(2));
+
+            return new ValueTask(context.SaveChangesAsync(TestCancellationToken));
+        });
+
+    [Fact]
+    public async ValueTask RematchGameSession_Created_WhenFinished()
+    {
+        await FinishSeededSessionAsync();
+
+        var response = await ApiClient.PostAsJsonAsync(
+            $"{BaseUrl}/{SeedData.SessionId}/rematch",
+            new GameSessionRematchRequest("REMAT1"),
+            JsonOptions,
+            TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var rematch = await response.Content.ReadFromJsonAsync<GameSessionDetailsDto>(JsonOptions, TestCancellationToken);
+        rematch.Should().NotBeNull();
+        rematch.Id.Should().NotBe(SeedData.SessionId);
+        rematch.Status.Should().Be(SessionStatus.Waiting);
+        rematch.JoinCode.Should().Be("REMAT1");
+        rematch.SessionName.Should().Be("Alpha Session");
+        rematch.HostUserId.Should().Be(SeedData.HostUserId);
+        rematch.PlannedDurationMinutes.Should().Be(120);
+        rematch.MrXRevealInterval.Should().Be(5);
+        rematch.StartTime.Should().BeNull();
+        rematch.EndTime.Should().BeNull();
+
+        // The finished session is preserved as history.
+        var original = await ApiClient.GetAsync($"{BaseUrl}/{SeedData.SessionId}", TestCancellationToken);
+        var originalContent = await original.Content.ReadFromJsonAsync<GameSessionDetailsDto>(JsonOptions, TestCancellationToken);
+        originalContent!.Status.Should().Be(SessionStatus.Finished);
+
+        // The rematch is an independent session reachable by its new join code.
+        var byCode = await ApiClient.GetAsync($"{BaseUrl}/join/REMAT1", TestCancellationToken);
+        byCode.StatusCode.Should().Be(HttpStatusCode.OK);
+        var byCodeContent = await byCode.Content.ReadFromJsonAsync<GameSessionDetailsDto>(JsonOptions, TestCancellationToken);
+        byCodeContent!.Id.Should().Be(rematch.Id);
+    }
+
+    [Fact]
+    public async ValueTask RematchGameSession_NotFound()
+    {
+        var response = await ApiClient.PostAsJsonAsync(
+            $"{BaseUrl}/9999/rematch",
+            new GameSessionRematchRequest("REMAT1"),
+            JsonOptions,
+            TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async ValueTask RematchGameSession_Conflict_WhenNotFinished()
+    {
+        // The seeded session is still Waiting, so it cannot be used for a rematch.
+        var response = await ApiClient.PostAsJsonAsync(
+            $"{BaseUrl}/{SeedData.SessionId}/rematch",
+            new GameSessionRematchRequest("REMAT1"),
+            JsonOptions,
+            TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
     // --- CatchMrX ---
 
     private async ValueTask ActivateSeededSessionAsync()

--- a/backend/XActBackend.TestInt/RealtimeHubTests.cs
+++ b/backend/XActBackend.TestInt/RealtimeHubTests.cs
@@ -94,6 +94,28 @@ public sealed class RealtimeHubTests : SeededWebApiTestBase
     }
 
     [Fact]
+    public async ValueTask EndGameSession_PublishesEndedEvent()
+    {
+        await ActivateSeedSessionAsync();
+
+        await using var realtimeClient = await SignalRTestClient.ConnectAsync(_fixture, TestCancellationToken);
+        await realtimeClient.SubscribeSessionAsync(SeedData.SessionId, TestCancellationToken);
+
+        HttpResponseMessage response = await ApiClient.PostAsync(
+            $"{BaseUrl}/{SeedData.SessionId}/end",
+            content: null,
+            cancellationToken: TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        RealtimeEventEnvelope? realtimeEvent = await realtimeClient.TryReadEventAsync(TimeSpan.FromSeconds(3), TestCancellationToken);
+
+        realtimeEvent.Should().NotBeNull();
+        realtimeEvent!.Type.Should().Be(RealtimeEvents.GameSessionEnded);
+        ((JsonElement)realtimeEvent.Payload).GetProperty("sessionId").GetInt32().Should().Be(SeedData.SessionId);
+    }
+
+    [Fact]
     public async ValueTask AddLocationLog_PublishesLocationEvent()
     {
         await ActivateSeedSessionAsync();

--- a/backend/XActBackend.TestInt/RealtimeHubTests.cs
+++ b/backend/XActBackend.TestInt/RealtimeHubTests.cs
@@ -262,4 +262,38 @@ public sealed class RealtimeHubTests : SeededWebApiTestBase
 
         memberStillExists.Should().BeFalse();
     }
+
+    [Fact]
+    public async ValueTask RematchGameSession_PublishesRematchCreatedEvent()
+    {
+        await ModifyDatabaseContentAsync(context =>
+        {
+            GameSession session = context.GameSessions.Single(session => session.Id == SeedData.SessionId);
+            session.Status = SessionStatus.Finished;
+            session.EndTime = SeedData.BaseInstant.Plus(Duration.FromHours(2));
+
+            return new ValueTask(context.SaveChangesAsync(TestCancellationToken));
+        });
+
+        await using var realtimeClient = await SignalRTestClient.ConnectAsync(_fixture, TestCancellationToken);
+        await realtimeClient.SubscribeSessionAsync(SeedData.SessionId, TestCancellationToken);
+
+        HttpResponseMessage response = await ApiClient.PostAsJsonAsync(
+            $"{BaseUrl}/{SeedData.SessionId}/rematch",
+            new GameSessionRematchRequest("REMAT2"),
+            JsonOptions,
+            TestCancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        RealtimeEventEnvelope? realtimeEvent = await realtimeClient.TryReadEventAsync(TimeSpan.FromSeconds(3), TestCancellationToken);
+
+        realtimeEvent.Should().NotBeNull();
+        realtimeEvent!.Type.Should().Be(RealtimeEvents.RematchCreated);
+
+        JsonElement payload = (JsonElement)realtimeEvent.Payload;
+        payload.GetProperty("finishedSessionId").GetInt32().Should().Be(SeedData.SessionId);
+        payload.GetProperty("newSessionId").GetInt32().Should().BeGreaterThan(0);
+        payload.GetProperty("newJoinCode").GetString().Should().Be("REMAT2");
+    }
 }

--- a/backend/XActBackend/Controllers/GameSessionController.cs
+++ b/backend/XActBackend/Controllers/GameSessionController.cs
@@ -283,6 +283,12 @@ public sealed class GameSessionController(
             return await result.Match<ValueTask<IActionResult>>(async success =>
             {
                 await transaction.CommitAsync();
+
+                OneOf<GameSession, NotFound> sessionResult = await gameSessionService.GetGameSessionByIdAsync(sessionId, tracking: false);
+                await sessionResult.Match(
+                    gameSession => realtimePublisher.PublishGameSessionEndedAsync(gameSession),
+                    _ => ValueTask.CompletedTask);
+
                 logger.LogInformation("Ended game session {SessionId}", sessionId);
 
                 return NoContent();

--- a/backend/XActBackend/Controllers/GameSessionController.cs
+++ b/backend/XActBackend/Controllers/GameSessionController.cs
@@ -7,6 +7,7 @@ using XActBackend.Core.Services;
 using XActBackend.Core.Realtime;
 using XActBackend.Persistence.Model;
 using XActBackend.Persistence.Util;
+using XActBackend.Realtime;
 using XActBackend.Util;
 
 namespace XActBackend.Controllers;
@@ -390,8 +391,13 @@ public sealed class GameSessionController(
         {
             await transaction.BeginTransactionAsync();
 
+            // Only carry over players still connected to the finished session so anyone who already
+            // left does not reappear in the new lobby as a ghost. A still-connected client is exactly
+            // the one that can migrate into the rematch.
+            IReadOnlySet<int> connectedMemberIds = GameSessionHub.GetConnectedMemberIds(sessionId);
+
             OneOf<GameSession, NotFound, DomainError> result =
-                await gameSessionService.CreateRematchSessionAsync(sessionId, request.JoinCode);
+                await gameSessionService.CreateRematchSessionAsync(sessionId, request.JoinCode, connectedMemberIds);
 
             return await result.Match<ValueTask<IActionResult>>(async rematchSession =>
             {

--- a/backend/XActBackend/Controllers/GameSessionController.cs
+++ b/backend/XActBackend/Controllers/GameSessionController.cs
@@ -365,6 +365,62 @@ public sealed class GameSessionController(
             return Problem();
         }
     }
+
+    [HttpPost]
+    [Route("{sessionId:int}/rematch")]
+    [ProducesResponseType<GameSessionDetailsDto>(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async ValueTask<IActionResult> RematchGameSession([FromRoute] int sessionId, [FromBody] GameSessionRematchRequest request)
+    {
+        if (!ValidateRequest<GameSessionRematchRequest.Validator, GameSessionRematchRequest>(request))
+        {
+            logger.LogWarning("Rejected rematch for game session {SessionId} because validation failed", sessionId);
+            return BadRequest();
+        }
+
+        try
+        {
+            await transaction.BeginTransactionAsync();
+
+            OneOf<GameSession, NotFound, DomainError> result =
+                await gameSessionService.CreateRematchSessionAsync(sessionId, request.JoinCode);
+
+            return await result.Match<ValueTask<IActionResult>>(async rematchSession =>
+            {
+                await transaction.CommitAsync();
+
+                // Announce on the finished session's channel so every still-connected client
+                // (host + players on the end-match screen) migrates into the new lobby.
+                await realtimePublisher.PublishRematchCreatedAsync(sessionId, rematchSession);
+
+                logger.LogInformation("Created rematch session {RematchSessionId} from finished session {SessionId}", rematchSession.Id, sessionId);
+
+                return CreatedAtAction(nameof(GetGameSessionById), new { sessionId = rematchSession.Id },
+                    GameSessionDetailsDto.FromGameSession(rematchSession, clock.GetCurrentInstant()));
+            }, async notFound =>
+            {
+                await transaction.RollbackAsync();
+                logger.LogWarning("Rejected rematch for game session {SessionId} because it was not found", sessionId);
+
+                return NotFound();
+            }, async domainError =>
+            {
+                await transaction.RollbackAsync();
+                logger.LogWarning("Rejected rematch for game session {SessionId} with domain error {ErrorCode}: {ErrorMessage}", sessionId, domainError.Code, domainError.Message);
+
+                return DomainErrorResult(domainError);
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to create rematch for game session {SessionId}", sessionId);
+            await transaction.RollbackAsync();
+
+            return Problem();
+        }
+    }
 }
 
 public sealed record CatchMrXRequest(int CatchingTeamId)
@@ -374,6 +430,17 @@ public sealed record CatchMrXRequest(int CatchingTeamId)
         public Validator()
         {
             RuleFor(x => x.CatchingTeamId).GreaterThan(0);
+        }
+    }
+}
+
+public sealed record GameSessionRematchRequest(string JoinCode)
+{
+    public sealed class Validator : AbstractValidator<GameSessionRematchRequest>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.JoinCode).NotEmpty().Length(6);
         }
     }
 }

--- a/backend/XActBackend/Realtime/GameSessionHub.cs
+++ b/backend/XActBackend/Realtime/GameSessionHub.cs
@@ -68,6 +68,17 @@ public sealed class GameSessionHub(
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    ///     The team-member ids that currently have a live realtime connection registered for the
+    ///     given session. A rematch uses this to keep players who have already left the finished
+    ///     session out of the new lobby (a still-connected client is exactly one that can migrate).
+    /// </summary>
+    public static IReadOnlySet<int> GetConnectedMemberIds(int sessionId) =>
+        presenceByConnection.Values
+            .Where(registration => registration.SessionId == sessionId)
+            .Select(registration => registration.MemberId)
+            .ToHashSet();
+
     public async Task<GameSessionSnapshot> SubscribeSession(int sessionId)
     {
         if (sessionId <= 0)

--- a/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
+++ b/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
@@ -135,6 +135,19 @@ internal sealed class GameSessionRealtimePublisher(
         return PublishToGroupAsync(group, message.SessionId, RealtimeEvents.ChatMessagePosted, payload);
     }
 
+    public ValueTask PublishRematchCreatedAsync(int finishedSessionId, GameSession newSession) =>
+        // Announce on the *finished* session's group so every client still subscribed to the
+        // ended match (host + players on the end-match screen) learns the new session to join.
+        PublishToSessionAsync(
+            finishedSessionId,
+            RealtimeEvents.RematchCreated,
+            new RematchCreatedPayload(
+                finishedSessionId,
+                newSession.Id,
+                newSession.JoinCode,
+                newSession.SessionName,
+                newSession.HostUserId));
+
     private ValueTask PublishToSessionAsync(int sessionId, string eventType, object payload) =>
         PublishToGroupAsync(RealtimeGroups.Session(sessionId), sessionId, eventType, payload);
 

--- a/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
+++ b/backend/XActBackend/Realtime/GameSessionRealtimePublisher.cs
@@ -87,6 +87,16 @@ internal sealed class GameSessionRealtimePublisher(
                 gameSession.StartTime,
                 gameSession.EndTime));
 
+    public ValueTask PublishGameSessionEndedAsync(GameSession gameSession) =>
+        PublishToSessionAsync(
+            gameSession.Id,
+            RealtimeEvents.GameSessionEnded,
+            new GameSessionEndedPayload(
+                gameSession.Id,
+                gameSession.Status,
+                gameSession.StartTime,
+                gameSession.EndTime));
+
     public ValueTask PublishLocationLogRecordedAsync(int sessionId, int teamId, LocationLog log) =>
         PublishToSessionAsync(
             sessionId,

--- a/backend/XActBackend/Util/BaseController.cs
+++ b/backend/XActBackend/Util/BaseController.cs
@@ -23,6 +23,7 @@ public abstract class BaseController : ControllerBase
             DomainErrorCodes.InvalidSessionTransition => StatusCodes.Status409Conflict,
             DomainErrorCodes.SessionNotJoinable => StatusCodes.Status409Conflict,
             DomainErrorCodes.SessionNotActive => StatusCodes.Status409Conflict,
+            DomainErrorCodes.SessionNotFinished => StatusCodes.Status409Conflict,
             DomainErrorCodes.MrXTeamAlreadyExists => StatusCodes.Status409Conflict,
             DomainErrorCodes.CatchingTeamNotEligible => StatusCodes.Status409Conflict,
             DomainErrorCodes.TeamHasMembers => StatusCodes.Status409Conflict,

--- a/xact_frontend/lib/api/api_service_session.dart
+++ b/xact_frontend/lib/api/api_service_session.dart
@@ -414,6 +414,12 @@ extension ApiServiceSessionMethods on ApiService {
       await _finishSession(details);
     }
 
+    // Drop the realtime presence registration before leaving so a rematch started
+    // after this point (e.g. on the end-match screen) does not copy this player,
+    // who has left, into the new lobby as a ghost.
+    try {
+      await _realtime.unregisterMemberPresence();
+    } catch (_) {}
     await _realtime.unsubscribeSession(sessionId);
 
     _session.currentSessionId = null;

--- a/xact_frontend/lib/api/api_service_session.dart
+++ b/xact_frontend/lib/api/api_service_session.dart
@@ -42,6 +42,24 @@ extension ApiServiceSessionMethods on ApiService {
     throw Exception('Failed to create lobby after retries.');
   }
 
+  /// Create a fresh lobby that copies the teams, players, area and settings of a
+  /// finished session. The backend broadcasts a `rematch_created` event on the
+  /// finished session's channel so every connected client migrates over.
+  Future<GameSessionDetails> createRematch(int finishedSessionId) async {
+    for (var attempt = 0; attempt < 3; attempt++) {
+      final response = await _postJsonObject(
+        '/api/gamesessions/$finishedSessionId/rematch',
+        {'joinCode': _generateJoinCode()},
+      );
+
+      if (response != null) {
+        return GameSessionDetails.fromJson(response);
+      }
+    }
+
+    throw Exception('Failed to create rematch after retries.');
+  }
+
   Future<int> ensureMvpUser({
     required String preferredName,
     bool reuseByName = false,

--- a/xact_frontend/lib/api/models.dart
+++ b/xact_frontend/lib/api/models.dart
@@ -616,6 +616,7 @@ final class RealtimeEvents {
   static const String teamMemberUpdated = 'team_member_updated';
   static const String teamMemberLeft = 'team_member_left';
   static const String gameSessionStarted = 'game_session_started';
+  static const String gameSessionEnded = 'game_session_ended';
   static const String locationLogRecorded = 'location_log_recorded';
   static const String mrXCaught = 'mr_x_caught';
   static const String chatMessagePosted = 'chat_message_posted';
@@ -1115,6 +1116,32 @@ final class GameSessionStartedPayload {
 
   factory GameSessionStartedPayload.fromJson(Map<String, dynamic> json) {
     return GameSessionStartedPayload(
+      status: switch (json['status']) {
+        final String s => tryParseSessionStatus(s),
+        _ => null,
+      },
+      startTime: tryParseIsoDateTime(json['startTime']),
+      endTime: tryParseIsoDateTime(json['endTime']),
+    );
+  }
+}
+
+final class GameSessionEndedPayload {
+  final int sessionId;
+  final SessionStatus? status;
+  final DateTime? startTime;
+  final DateTime? endTime;
+
+  const GameSessionEndedPayload({
+    required this.sessionId,
+    required this.status,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  factory GameSessionEndedPayload.fromJson(Map<String, dynamic> json) {
+    return GameSessionEndedPayload(
+      sessionId: _readInt(json, ['sessionId']),
       status: switch (json['status']) {
         final String s => tryParseSessionStatus(s),
         _ => null,

--- a/xact_frontend/lib/api/models.dart
+++ b/xact_frontend/lib/api/models.dart
@@ -619,6 +619,7 @@ final class RealtimeEvents {
   static const String locationLogRecorded = 'location_log_recorded';
   static const String mrXCaught = 'mr_x_caught';
   static const String chatMessagePosted = 'chat_message_posted';
+  static const String rematchCreated = 'rematch_created';
 }
 
 final class RealtimeEventEnvelope {
@@ -1120,6 +1121,35 @@ final class GameSessionStartedPayload {
       },
       startTime: tryParseIsoDateTime(json['startTime']),
       endTime: tryParseIsoDateTime(json['endTime']),
+    );
+  }
+}
+
+/// Realtime `rematch_created` payload. Broadcast on the finished session's
+/// channel so every still-connected client can migrate into the fresh lobby
+/// identified by [newSessionId] / [newJoinCode].
+final class RematchCreatedPayload {
+  final int finishedSessionId;
+  final int newSessionId;
+  final String newJoinCode;
+  final String sessionName;
+  final int hostUserId;
+
+  const RematchCreatedPayload({
+    required this.finishedSessionId,
+    required this.newSessionId,
+    required this.newJoinCode,
+    required this.sessionName,
+    required this.hostUserId,
+  });
+
+  factory RematchCreatedPayload.fromJson(Map<String, dynamic> json) {
+    return RematchCreatedPayload(
+      finishedSessionId: _readInt(json, ['finishedSessionId']),
+      newSessionId: _readInt(json, ['newSessionId']),
+      newJoinCode: (json['newJoinCode'] as String?) ?? '',
+      sessionName: (json['sessionName'] as String?) ?? 'Session',
+      hostUserId: _readInt(json, ['hostUserId']),
     );
   }
 }

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -135,21 +135,12 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     }
     _migrating = true;
 
-    final currentUserId = AppSession.instance.currentUserId;
-    // Point the session state at the new lobby and drop the finished session's
-    // membership; the lobby re-resolves the player's new membership on load.
-    AppSession.instance.setSession(sessionId: sessionId, joinCode: joinCode);
-    AppSession.instance.clearMembership();
-
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(
-        builder: (_) => GameLobbyScreen(
-          sessionId: sessionId,
-          gameCode: joinCode,
-          gameName: sessionName,
-          isLeader: currentUserId != null && currentUserId == hostUserId,
-        ),
-      ),
+    openRematchLobby(
+      context,
+      sessionId: sessionId,
+      joinCode: joinCode,
+      sessionName: sessionName,
+      hostUserId: hostUserId,
     );
   }
 

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:xact_frontend/api/api_service.dart';
 import 'package:xact_frontend/api/models.dart';
 import 'package:xact_frontend/screens/start/start_screen.dart';
-import 'package:xact_frontend/screens/team/team_lobby.dart';
-import 'package:xact_frontend/services/app_session.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
 class EndMatchScreen extends StatefulWidget {
@@ -152,17 +150,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
         .length;
   }
 
-  List<TeamDetails> get _playableTeams {
-    final snapshot = _snapshot;
-    if (snapshot == null) {
-      return const [];
-    }
-
-    return snapshot.teams
-        .where((team) => team.role != TeamRole.spectator)
-        .toList(growable: false);
-  }
-
   String _formatDuration(Duration duration) {
     final totalMinutes = duration.inMinutes;
     final hours = totalMinutes ~/ 60;
@@ -195,52 +182,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     final hour = local.hour.toString().padLeft(2, '0');
     final minute = local.minute.toString().padLeft(2, '0');
     return '$day.$month.$year $hour:$minute';
-  }
-
-  String _roleLabel(TeamRole? role) => switch (role) {
-    TeamRole.mrX => 'Mister X',
-    TeamRole.detective => 'Detective',
-    TeamRole.spectator => 'Spectator',
-    null => 'Team',
-  };
-
-  Color _roleColor(TeamRole? role) => XActColors.roleColor(role);
-
-  Future<void> _backToLobby() async {
-    setState(() => _working = true);
-    try {
-      final details =
-          _sessionDetails ??
-          await ApiService.instance.getGameSession(widget.sessionId);
-      if (!mounted) {
-        return;
-      }
-
-      final currentUserId = AppSession.instance.currentUserId;
-      await Navigator.of(context).pushReplacement(
-        MaterialPageRoute(
-          builder: (_) => GameLobbyScreen(
-            sessionId: widget.sessionId,
-            gameCode: details.joinCode,
-            gameName: details.sessionName,
-            isLeader:
-                currentUserId != null && currentUserId == details.hostUserId,
-          ),
-        ),
-      );
-    } catch (error) {
-      if (!mounted) {
-        return;
-      }
-
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not reopen lobby: $error')));
-    } finally {
-      if (mounted) {
-        setState(() => _working = false);
-      }
-    }
   }
 
   Future<void> _leaveLobby() async {
@@ -323,7 +264,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
       _buildResultHero(),
       _buildStatGrid(),
       _buildMatchDetailsSection(),
-      _buildTeamsSection(),
       _buildSessionSection(),
     ];
 
@@ -463,80 +403,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     );
   }
 
-  Widget _buildTeamsSection() {
-    final teams = _playableTeams;
-    if (teams.isEmpty) {
-      return _SectionCard(
-        title: 'Teams',
-        subtitle: 'Final standings for every playable team.',
-        child: Text(
-          'No team data available',
-          style: XActText.bodySm.copyWith(color: XActColors.text3),
-        ),
-      );
-    }
-
-    return Column(
-      children: [
-        for (var index = 0; index < teams.length; index++) ...[
-          if (index > 0) const SizedBox(height: _sectionGap),
-          _buildTeamCard(teams[index]),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildTeamCard(TeamDetails team) {
-    final members = _snapshot!.membersByTeamId[team.teamId] ?? const [];
-
-    return _SectionCard(
-      title: team.teamName,
-      subtitle: _roleLabel(team.role),
-      leadingColor: _roleColor(team.role),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Wrap(
-            spacing: _bubbleGridGap,
-            runSpacing: _bubbleGridGap,
-            children: [
-              _TagChip(
-                text: team.isCaught ? 'Caught' : 'Active',
-                color: team.isCaught ? XActColors.primary : XActColors.success,
-              ),
-              _TagChip(
-                text: '${members.length} players',
-                color: XActColors.secondary,
-              ),
-            ],
-          ),
-          if (members.isNotEmpty) ...[
-            const SizedBox(height: XActSpace.s3),
-            Wrap(
-              spacing: XActSpace.s2,
-              runSpacing: XActSpace.s2,
-              children: [
-                for (final member in members)
-                  _TagChip(
-                    text: _memberLabel(member),
-                    color: member.isTeamLeader
-                        ? XActColors.warning
-                        : XActColors.text4,
-                  ),
-              ],
-            ),
-          ] else ...[
-            const SizedBox(height: XActSpace.s3),
-            Text(
-              'No players assigned to this team.',
-              style: XActText.caption.copyWith(color: XActColors.text4),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
   Widget _buildSessionSection() {
     final details = _sessionDetails;
 
@@ -623,13 +489,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
                   ),
                 ),
               ],
-              XActBranding.buildSecondaryButton(
-                text: 'Back to Lobby',
-                icon: Icons.meeting_room_rounded,
-                onPressed: _working ? null : _backToLobby,
-                height: 54,
-              ),
-              const SizedBox(height: XActSpace.s3),
               XActBranding.buildGhostButton(
                 text: 'Leave Lobby',
                 icon: Icons.logout_rounded,
@@ -643,17 +502,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     );
   }
 
-  String _memberLabel(TeamMemberDetails member) {
-    if (member.guestName != null && member.guestName!.trim().isNotEmpty) {
-      return member.guestName!.trim();
-    }
-
-    if (member.userId != null) {
-      return 'User ${member.userId}';
-    }
-
-    return 'Player ${member.memberId}';
-  }
 }
 
 class _DetailRow extends StatelessWidget {
@@ -738,13 +586,11 @@ class _SectionCard extends StatelessWidget {
   final String title;
   final String subtitle;
   final Widget child;
-  final Color? leadingColor;
 
   const _SectionCard({
     required this.title,
     required this.subtitle,
     required this.child,
-    this.leadingColor,
   });
 
   @override
@@ -767,9 +613,9 @@ class _SectionCard extends StatelessWidget {
                 width: 10,
                 height: 10,
                 margin: const EdgeInsets.only(top: 6, right: XActSpace.s2),
-                decoration: BoxDecoration(
+                decoration: const BoxDecoration(
                   shape: BoxShape.circle,
-                  color: leadingColor ?? XActColors.secondary,
+                  color: XActColors.secondary,
                 ),
               ),
               Expanded(
@@ -790,35 +636,6 @@ class _SectionCard extends StatelessWidget {
           const SizedBox(height: 16),
           child,
         ],
-      ),
-    );
-  }
-}
-
-class _TagChip extends StatelessWidget {
-  final String text;
-  final Color color;
-
-  const _TagChip({required this.text, required this.color});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: XActSpace.s3,
-        vertical: XActSpace.s2,
-      ),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: .14),
-        borderRadius: XActRadius.pill,
-        border: Border.all(color: color.withValues(alpha: .35)),
-      ),
-      child: Text(
-        text,
-        style: XActText.caption.copyWith(
-          color: color,
-          fontWeight: FontWeight.w700,
-        ),
       ),
     );
   }

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -15,11 +15,10 @@ class EndMatchScreen extends StatefulWidget {
   State<EndMatchScreen> createState() => _EndMatchScreenState();
 }
 
-class _EndMatchScreenState extends State<EndMatchScreen>
-    with SingleTickerProviderStateMixin {
-  static const double _tabContentPaddingTop = XActSpace.s4;
-  static const double _tabContentPaddingBottom = XActSpace.s6;
-  static const double _tabSectionGap = XActSpace.s4;
+class _EndMatchScreenState extends State<EndMatchScreen> {
+  static const double _pagePaddingTop = XActSpace.s2;
+  static const double _pagePaddingBottom = XActSpace.s6;
+  static const double _sectionGap = XActSpace.s4;
   static const double _bubbleGridGap = XActSpace.s3;
   static const double _bubbleGridWideBreakpoint = 720;
 
@@ -27,19 +26,11 @@ class _EndMatchScreenState extends State<EndMatchScreen>
   bool _working = false;
   GameSessionDetails? _sessionDetails;
   LobbySnapshot? _snapshot;
-  late final TabController _tabController;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
     _loadSummary();
-  }
-
-  @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
   }
 
   Future<void> _loadSummary() async {
@@ -307,31 +298,12 @@ class _EndMatchScreenState extends State<EndMatchScreen>
                             showBack: false,
                           ),
                         ),
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                            XActSpace.s4,
-                            XActSpace.s2,
-                            XActSpace.s4,
-                            XActSpace.s4,
-                          ),
-                          child: _buildHeaderCard(),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: XActSpace.s4,
-                          ),
-                          child: _buildTabBar(),
-                        ),
-                        const SizedBox(height: XActSpace.s3),
                         Expanded(
-                          child: TabBarView(
-                            controller: _tabController,
-                            children: [
-                              _buildOverviewTab(),
-                              _buildTeamsTab(),
-                              _buildSessionTab(),
-                            ],
-                          ),
+                          child: _loading
+                              ? const Center(
+                                  child: CircularProgressIndicator(),
+                                )
+                              : _buildSummaryBody(),
                         ),
                         _buildActionArea(),
                       ],
@@ -343,6 +315,28 @@ class _EndMatchScreenState extends State<EndMatchScreen>
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildSummaryBody() {
+    final sections = <Widget>[
+      _buildHeaderCard(),
+      ..._buildOverviewSections(),
+      _buildTeamsSection(),
+      ..._buildSessionSections(),
+    ];
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(
+        XActSpace.s4,
+        _pagePaddingTop,
+        XActSpace.s4,
+        _pagePaddingBottom,
+      ),
+      itemCount: sections.length,
+      separatorBuilder: (context, index) =>
+          const SizedBox(height: _sectionGap),
+      itemBuilder: (context, index) => sections[index],
     );
   }
 
@@ -387,176 +381,112 @@ class _EndMatchScreenState extends State<EndMatchScreen>
             ],
           ),
           const SizedBox(height: XActSpace.s4),
-          if (_loading)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: XActSpace.s4),
-              child: Center(child: CircularProgressIndicator()),
-            )
-          else ...[
-            Row(
-              children: [
-                Expanded(
-                  child: _MiniStatCard(
-                    label: 'Winner',
-                    value: _winnerTeamName ?? 'Not available',
-                    accent: _roleColor(TeamRole.mrX),
-                  ),
+          Row(
+            children: [
+              Expanded(
+                child: _MiniStatCard(
+                  label: 'Winner',
+                  value: _winnerTeamName ?? 'Not available',
+                  accent: _roleColor(TeamRole.mrX),
                 ),
-                const SizedBox(width: XActSpace.s3),
-                Expanded(
-                  child: _MiniStatCard(
-                    label: 'Duration',
-                    value: _matchDurationText ?? 'Not available',
-                    accent: XActColors.secondary,
-                  ),
+              ),
+              const SizedBox(width: XActSpace.s3),
+              Expanded(
+                child: _MiniStatCard(
+                  label: 'Duration',
+                  value: _matchDurationText ?? 'Not available',
+                  accent: XActColors.secondary,
                 ),
-              ],
-            ),
-            const SizedBox(height: XActSpace.s3),
-            Row(
-              children: [
-                Expanded(
-                  child: _MiniStatCard(
-                    label: 'Teams',
-                    value: '$_teamCount',
-                    accent: XActColors.success,
-                  ),
-                ),
-                const SizedBox(width: XActSpace.s3),
-                Expanded(
-                  child: _MiniStatCard(
-                    label: 'Players',
-                    value: '$_playerCount',
-                    accent: XActColors.warning,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: XActSpace.s3),
-            _DetailRow(
-              label: 'Status',
-              value: _sessionDetails?.status == SessionStatus.finished
-                  ? 'Finished'
-                  : 'Summary loaded',
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTabBar() {
-    return Container(
-      padding: const EdgeInsets.all(XActSpace.s1),
-      decoration: BoxDecoration(
-        color: XActColors.surface,
-        borderRadius: XActRadius.lg,
-        border: Border.all(color: XActColors.hairlineSoft),
-        boxShadow: XActElevation.e1,
-      ),
-      child: TabBar(
-        controller: _tabController,
-        isScrollable: false,
-        indicatorSize: TabBarIndicatorSize.tab,
-        labelPadding: const EdgeInsets.symmetric(
-          horizontal: XActSpace.s3,
-          vertical: XActSpace.s2,
-        ),
-        indicatorPadding: const EdgeInsets.all(2),
-        labelColor: Colors.white,
-        unselectedLabelColor: XActColors.text3,
-        indicator: BoxDecoration(
-          borderRadius: XActRadius.md,
-          gradient: const LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [XActColors.secondaryLight, XActColors.secondaryDark],
+              ),
+            ],
           ),
-        ),
-        dividerColor: Colors.transparent,
-        labelStyle: XActText.bodySm.copyWith(fontWeight: FontWeight.w700),
-        unselectedLabelStyle: XActText.bodySm.copyWith(
-          fontWeight: FontWeight.w600,
-        ),
-        tabs: const [
-          Tab(text: 'Overview'),
-          Tab(text: 'Teams'),
-          Tab(text: 'Session'),
+          const SizedBox(height: XActSpace.s3),
+          Row(
+            children: [
+              Expanded(
+                child: _MiniStatCard(
+                  label: 'Teams',
+                  value: '$_teamCount',
+                  accent: XActColors.success,
+                ),
+              ),
+              const SizedBox(width: XActSpace.s3),
+              Expanded(
+                child: _MiniStatCard(
+                  label: 'Players',
+                  value: '$_playerCount',
+                  accent: XActColors.warning,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: XActSpace.s3),
+          _DetailRow(
+            label: 'Status',
+            value: _sessionDetails?.status == SessionStatus.finished
+                ? 'Finished'
+                : 'Summary loaded',
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildOverviewTab() {
-    if (_loading) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
+  List<Widget> _buildOverviewSections() {
     final snapshot = _snapshot;
     final details = _sessionDetails;
 
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(
-        XActSpace.s4,
-        _tabContentPaddingTop,
-        XActSpace.s4,
-        _tabContentPaddingBottom,
+    return [
+      _SectionCard(
+        title: 'Result snapshot',
+        subtitle: 'A compact recap using the current session data.',
+        child: _buildDetailBubbleGrid(
+          children: [
+            _DetailRow(
+              label: 'Winning Team',
+              value: _winnerTeamName ?? 'Not available',
+            ),
+            _DetailRow(
+              label: 'Match Duration',
+              value: _matchDurationText ?? 'Not available',
+            ),
+            _DetailRow(
+              label: 'Planned Duration',
+              value: '${details?.plannedDurationMinutes ?? 0} min',
+            ),
+            _DetailRow(
+              label: 'Reveal Interval',
+              value: '${details?.mrXRevealInterval ?? 0} min',
+            ),
+          ],
+        ),
       ),
-      children: [
-        _SectionCard(
-          title: 'Result snapshot',
-          subtitle: 'A compact recap using the current session data.',
-          child: _buildDetailBubbleGrid(
-            children: [
-              _DetailRow(
-                label: 'Winning Team',
-                value: _winnerTeamName ?? 'Not available',
-              ),
-              _DetailRow(
-                label: 'Match Duration',
-                value: _matchDurationText ?? 'Not available',
-              ),
-              _DetailRow(
-                label: 'Planned Duration',
-                value: '${details?.plannedDurationMinutes ?? 0} min',
-              ),
-              _DetailRow(
-                label: 'Reveal Interval',
-                value: '${details?.mrXRevealInterval ?? 0} min',
-              ),
-            ],
-          ),
+      _SectionCard(
+        title: 'Status summary',
+        subtitle: 'Useful end-of-match signals from the backend.',
+        child: _buildDetailBubbleGrid(
+          children: [
+            _DetailRow(
+              label: 'Session Status',
+              value: _sessionDetails?.status?.name ?? 'Unknown',
+            ),
+            _DetailRow(label: 'Players in Session', value: '$_playerCount'),
+            _DetailRow(
+              label: 'Latest Location Points',
+              value: '${snapshot?.latestLocations.length ?? 0}',
+            ),
+          ],
         ),
-        const SizedBox(height: _tabSectionGap),
-        _SectionCard(
-          title: 'Status summary',
-          subtitle: 'Useful end-of-match signals from the backend.',
-          child: _buildDetailBubbleGrid(
-            children: [
-              _DetailRow(
-                label: 'Session Status',
-                value: _sessionDetails?.status?.name ?? 'Unknown',
-              ),
-              _DetailRow(label: 'Players in Session', value: '$_playerCount'),
-              _DetailRow(
-                label: 'Latest Location Points',
-                value: '${snapshot?.latestLocations.length ?? 0}',
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
+      ),
+    ];
   }
 
-  Widget _buildTeamsTab() {
-    if (_loading) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
+  Widget _buildTeamsSection() {
     final teams = _playableTeams;
     if (teams.isEmpty) {
-      return Center(
+      return _SectionCard(
+        title: 'Teams',
+        subtitle: 'Final standings for every playable team.',
         child: Text(
           'No team data available',
           style: XActText.bodySm.copyWith(color: XActColors.text3),
@@ -564,135 +494,116 @@ class _EndMatchScreenState extends State<EndMatchScreen>
       );
     }
 
-    return ListView.separated(
-      padding: const EdgeInsets.fromLTRB(
-        XActSpace.s4,
-        _tabContentPaddingTop,
-        XActSpace.s4,
-        _tabContentPaddingBottom,
-      ),
-      itemCount: teams.length,
-      separatorBuilder: (context, index) =>
-          const SizedBox(height: _tabSectionGap),
-      itemBuilder: (context, index) {
-        final team = teams[index];
-        final members = _snapshot!.membersByTeamId[team.teamId] ?? const [];
-
-        return _SectionCard(
-          title: team.teamName,
-          subtitle: _roleLabel(team.role),
-          leadingColor: _roleColor(team.role),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Wrap(
-                spacing: _bubbleGridGap,
-                runSpacing: _bubbleGridGap,
-                children: [
-                  _TagChip(
-                    text: team.isCaught ? 'Caught' : 'Active',
-                    color: team.isCaught
-                        ? XActColors.primary
-                        : XActColors.success,
-                  ),
-                  _TagChip(
-                    text: '${members.length} players',
-                    color: XActColors.secondary,
-                  ),
-                ],
-              ),
-              if (members.isNotEmpty) ...[
-                const SizedBox(height: XActSpace.s3),
-                Wrap(
-                  spacing: XActSpace.s2,
-                  runSpacing: XActSpace.s2,
-                  children: [
-                    for (final member in members)
-                      _TagChip(
-                        text: _memberLabel(member),
-                        color: member.isTeamLeader
-                            ? XActColors.warning
-                            : XActColors.text4,
-                      ),
-                  ],
-                ),
-              ] else ...[
-                const SizedBox(height: XActSpace.s3),
-                Text(
-                  'No players assigned to this team.',
-                  style: XActText.caption.copyWith(color: XActColors.text4),
-                ),
-              ],
-            ],
-          ),
-        );
-      },
+    return Column(
+      children: [
+        for (var index = 0; index < teams.length; index++) ...[
+          if (index > 0) const SizedBox(height: _sectionGap),
+          _buildTeamCard(teams[index]),
+        ],
+      ],
     );
   }
 
-  Widget _buildSessionTab() {
-    if (_loading) {
-      return const Center(child: CircularProgressIndicator());
-    }
+  Widget _buildTeamCard(TeamDetails team) {
+    final members = _snapshot!.membersByTeamId[team.teamId] ?? const [];
 
-    final details = _sessionDetails;
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(
-        XActSpace.s4,
-        _tabContentPaddingTop,
-        XActSpace.s4,
-        _tabContentPaddingBottom,
+    return _SectionCard(
+      title: team.teamName,
+      subtitle: _roleLabel(team.role),
+      leadingColor: _roleColor(team.role),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: _bubbleGridGap,
+            runSpacing: _bubbleGridGap,
+            children: [
+              _TagChip(
+                text: team.isCaught ? 'Caught' : 'Active',
+                color: team.isCaught ? XActColors.primary : XActColors.success,
+              ),
+              _TagChip(
+                text: '${members.length} players',
+                color: XActColors.secondary,
+              ),
+            ],
+          ),
+          if (members.isNotEmpty) ...[
+            const SizedBox(height: XActSpace.s3),
+            Wrap(
+              spacing: XActSpace.s2,
+              runSpacing: XActSpace.s2,
+              children: [
+                for (final member in members)
+                  _TagChip(
+                    text: _memberLabel(member),
+                    color: member.isTeamLeader
+                        ? XActColors.warning
+                        : XActColors.text4,
+                  ),
+              ],
+            ),
+          ] else ...[
+            const SizedBox(height: XActSpace.s3),
+            Text(
+              'No players assigned to this team.',
+              style: XActText.caption.copyWith(color: XActColors.text4),
+            ),
+          ],
+        ],
       ),
-      children: [
-        _SectionCard(
-          title: 'Match timing',
-          subtitle:
-              'The backend only provides the session timing fields below.',
-          child: _buildDetailBubbleGrid(
-            children: [
-              _DetailRow(
-                label: 'Session Name',
-                value: details?.sessionName ?? 'Not available',
-              ),
-              _DetailRow(
-                label: 'Session ID',
-                value: '${details?.sessionId ?? widget.sessionId}',
-              ),
-              _DetailRow(
-                label: 'Start Time',
-                value: _formatDateTime(details?.startTime),
-              ),
-              _DetailRow(
-                label: 'End Time',
-                value: _formatDateTime(details?.endTime),
-              ),
-              _DetailRow(
-                label: 'Match Duration',
-                value: _matchDurationText ?? 'Not available',
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: _tabSectionGap),
-        _SectionCard(
-          title: 'Match configuration',
-          subtitle: 'Useful settings already known at end of play.',
-          child: _buildDetailBubbleGrid(
-            children: [
-              _DetailRow(
-                label: 'Planned Duration',
-                value: '${details?.plannedDurationMinutes ?? 0} min',
-              ),
-              _DetailRow(
-                label: 'Reveal Interval',
-                value: '${details?.mrXRevealInterval ?? 0} min',
-              ),
-              _DetailRow(label: 'Caught Teams', value: '$_caughtTeamCount'),
-            ],
-          ),
-        ),
-      ],
     );
+  }
+
+  List<Widget> _buildSessionSections() {
+    final details = _sessionDetails;
+    return [
+      _SectionCard(
+        title: 'Match timing',
+        subtitle: 'The backend only provides the session timing fields below.',
+        child: _buildDetailBubbleGrid(
+          children: [
+            _DetailRow(
+              label: 'Session Name',
+              value: details?.sessionName ?? 'Not available',
+            ),
+            _DetailRow(
+              label: 'Session ID',
+              value: '${details?.sessionId ?? widget.sessionId}',
+            ),
+            _DetailRow(
+              label: 'Start Time',
+              value: _formatDateTime(details?.startTime),
+            ),
+            _DetailRow(
+              label: 'End Time',
+              value: _formatDateTime(details?.endTime),
+            ),
+            _DetailRow(
+              label: 'Match Duration',
+              value: _matchDurationText ?? 'Not available',
+            ),
+          ],
+        ),
+      ),
+      _SectionCard(
+        title: 'Match configuration',
+        subtitle: 'Useful settings already known at end of play.',
+        child: _buildDetailBubbleGrid(
+          children: [
+            _DetailRow(
+              label: 'Planned Duration',
+              value: '${details?.plannedDurationMinutes ?? 0} min',
+            ),
+            _DetailRow(
+              label: 'Reveal Interval',
+              value: '${details?.mrXRevealInterval ?? 0} min',
+            ),
+            _DetailRow(label: 'Caught Teams', value: '$_caughtTeamCount'),
+          ],
+        ),
+      ),
+    ];
   }
 
   Widget _buildDetailBubbleGrid({required List<Widget> children}) {

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -320,10 +320,11 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
 
   Widget _buildSummaryBody() {
     final sections = <Widget>[
-      _buildHeaderCard(),
-      ..._buildOverviewSections(),
+      _buildResultHero(),
+      _buildStatGrid(),
+      _buildMatchDetailsSection(),
       _buildTeamsSection(),
-      ..._buildSessionSections(),
+      _buildSessionSection(),
     ];
 
     return ListView.separated(
@@ -340,145 +341,126 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     );
   }
 
-  Widget _buildHeaderCard() {
+  Widget _buildResultHero() {
+    final winner = _winnerTeamName;
+    final hasWinner = winner != null;
+    final accent = hasWinner ? XActColors.success : XActColors.secondary;
+
     return XActBranding.buildFormCard(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  color: XActColors.primarySoft,
-                  borderRadius: XActRadius.md,
-                  border: Border.all(color: XActColors.hairlineSoft),
-                ),
-                child: const Icon(
-                  Icons.flag_rounded,
-                  color: XActColors.primary,
-                  size: 30,
-                ),
-              ),
-              const SizedBox(width: XActSpace.s4),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Match beendet',
-                      style: XActText.displaySm.copyWith(fontSize: 30),
-                    ),
-                    const SizedBox(height: XActSpace.s1),
-                    Text(
-                      _summaryText,
-                      style: XActText.body.copyWith(color: XActColors.text2),
-                    ),
-                  ],
-                ),
-              ),
-            ],
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: .16),
+              borderRadius: XActRadius.lg,
+              border: Border.all(color: accent.withValues(alpha: .45)),
+            ),
+            child: Icon(
+              hasWinner ? Icons.emoji_events_rounded : Icons.flag_rounded,
+              color: accent,
+              size: 32,
+            ),
           ),
-          const SizedBox(height: XActSpace.s4),
-          Row(
-            children: [
-              Expanded(
-                child: _MiniStatCard(
-                  label: 'Winner',
-                  value: _winnerTeamName ?? 'Not available',
-                  accent: _roleColor(TeamRole.mrX),
+          const SizedBox(width: XActSpace.s4),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                XActBranding.buildEyebrow(hasWinner ? 'Winner' : 'Result'),
+                const SizedBox(height: XActSpace.s1),
+                Text(
+                  winner ?? 'No winner recorded',
+                  style: XActText.displaySm.copyWith(fontSize: 28),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
-              ),
-              const SizedBox(width: XActSpace.s3),
-              Expanded(
-                child: _MiniStatCard(
-                  label: 'Duration',
-                  value: _matchDurationText ?? 'Not available',
-                  accent: XActColors.secondary,
+                const SizedBox(height: XActSpace.s2),
+                Text(
+                  _summaryText,
+                  style: XActText.body.copyWith(color: XActColors.text2),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: XActSpace.s3),
-          Row(
-            children: [
-              Expanded(
-                child: _MiniStatCard(
-                  label: 'Teams',
-                  value: '$_teamCount',
-                  accent: XActColors.success,
-                ),
-              ),
-              const SizedBox(width: XActSpace.s3),
-              Expanded(
-                child: _MiniStatCard(
-                  label: 'Players',
-                  value: '$_playerCount',
-                  accent: XActColors.warning,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: XActSpace.s3),
-          _DetailRow(
-            label: 'Status',
-            value: _sessionDetails?.status == SessionStatus.finished
-                ? 'Finished'
-                : 'Summary loaded',
+              ],
+            ),
           ),
         ],
       ),
     );
   }
 
-  List<Widget> _buildOverviewSections() {
+  Widget _buildStatGrid() {
+    final stats = <Widget>[
+      _MiniStatCard(
+        label: 'Duration',
+        value: _matchDurationText ?? 'Not available',
+        accent: XActColors.secondary,
+      ),
+      _MiniStatCard(
+        label: 'Teams',
+        value: '$_teamCount',
+        accent: XActColors.success,
+      ),
+      _MiniStatCard(
+        label: 'Players',
+        value: '$_playerCount',
+        accent: XActColors.warning,
+      ),
+      _MiniStatCard(
+        label: 'Caught',
+        value: '$_caughtTeamCount',
+        accent: XActColors.primary,
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns =
+            constraints.maxWidth >= _bubbleGridWideBreakpoint ? 4 : 2;
+        final itemWidth =
+            (constraints.maxWidth - _bubbleGridGap * (columns - 1)) / columns;
+
+        return Wrap(
+          spacing: _bubbleGridGap,
+          runSpacing: _bubbleGridGap,
+          children: [
+            for (final stat in stats)
+              SizedBox(width: itemWidth, child: stat),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildMatchDetailsSection() {
     final snapshot = _snapshot;
     final details = _sessionDetails;
 
-    return [
-      _SectionCard(
-        title: 'Result snapshot',
-        subtitle: 'A compact recap using the current session data.',
-        child: _buildDetailBubbleGrid(
-          children: [
-            _DetailRow(
-              label: 'Winning Team',
-              value: _winnerTeamName ?? 'Not available',
-            ),
-            _DetailRow(
-              label: 'Match Duration',
-              value: _matchDurationText ?? 'Not available',
-            ),
-            _DetailRow(
-              label: 'Planned Duration',
-              value: '${details?.plannedDurationMinutes ?? 0} min',
-            ),
-            _DetailRow(
-              label: 'Reveal Interval',
-              value: '${details?.mrXRevealInterval ?? 0} min',
-            ),
-          ],
-        ),
+    return _SectionCard(
+      title: 'Match details',
+      subtitle: 'Configuration and end-of-match signals from the backend.',
+      child: _buildDetailBubbleGrid(
+        children: [
+          _DetailRow(
+            label: 'Session Status',
+            value: details?.status?.name ?? 'Unknown',
+          ),
+          _DetailRow(
+            label: 'Planned Duration',
+            value: '${details?.plannedDurationMinutes ?? 0} min',
+          ),
+          _DetailRow(
+            label: 'Reveal Interval',
+            value: '${details?.mrXRevealInterval ?? 0} min',
+          ),
+          _DetailRow(
+            label: 'Latest Location Points',
+            value: '${snapshot?.latestLocations.length ?? 0}',
+          ),
+        ],
       ),
-      _SectionCard(
-        title: 'Status summary',
-        subtitle: 'Useful end-of-match signals from the backend.',
-        child: _buildDetailBubbleGrid(
-          children: [
-            _DetailRow(
-              label: 'Session Status',
-              value: _sessionDetails?.status?.name ?? 'Unknown',
-            ),
-            _DetailRow(label: 'Players in Session', value: '$_playerCount'),
-            _DetailRow(
-              label: 'Latest Location Points',
-              value: '${snapshot?.latestLocations.length ?? 0}',
-            ),
-          ],
-        ),
-      ),
-    ];
+    );
   }
 
   Widget _buildTeamsSection() {
@@ -555,55 +537,33 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
     );
   }
 
-  List<Widget> _buildSessionSections() {
+  Widget _buildSessionSection() {
     final details = _sessionDetails;
-    return [
-      _SectionCard(
-        title: 'Match timing',
-        subtitle: 'The backend only provides the session timing fields below.',
-        child: _buildDetailBubbleGrid(
-          children: [
-            _DetailRow(
-              label: 'Session Name',
-              value: details?.sessionName ?? 'Not available',
-            ),
-            _DetailRow(
-              label: 'Session ID',
-              value: '${details?.sessionId ?? widget.sessionId}',
-            ),
-            _DetailRow(
-              label: 'Start Time',
-              value: _formatDateTime(details?.startTime),
-            ),
-            _DetailRow(
-              label: 'End Time',
-              value: _formatDateTime(details?.endTime),
-            ),
-            _DetailRow(
-              label: 'Match Duration',
-              value: _matchDurationText ?? 'Not available',
-            ),
-          ],
-        ),
+
+    return _SectionCard(
+      title: 'Session',
+      subtitle: 'Identifiers and timing recorded for this match.',
+      child: _buildDetailBubbleGrid(
+        children: [
+          _DetailRow(
+            label: 'Session Name',
+            value: details?.sessionName ?? 'Not available',
+          ),
+          _DetailRow(
+            label: 'Session ID',
+            value: '${details?.sessionId ?? widget.sessionId}',
+          ),
+          _DetailRow(
+            label: 'Start Time',
+            value: _formatDateTime(details?.startTime),
+          ),
+          _DetailRow(
+            label: 'End Time',
+            value: _formatDateTime(details?.endTime),
+          ),
+        ],
       ),
-      _SectionCard(
-        title: 'Match configuration',
-        subtitle: 'Useful settings already known at end of play.',
-        child: _buildDetailBubbleGrid(
-          children: [
-            _DetailRow(
-              label: 'Planned Duration',
-              value: '${details?.plannedDurationMinutes ?? 0} min',
-            ),
-            _DetailRow(
-              label: 'Reveal Interval',
-              value: '${details?.mrXRevealInterval ?? 0} min',
-            ),
-            _DetailRow(label: 'Caught Teams', value: '$_caughtTeamCount'),
-          ],
-        ),
-      ),
-    ];
+    );
   }
 
   Widget _buildDetailBubbleGrid({required List<Widget> children}) {
@@ -663,11 +623,6 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
                   ),
                 ),
               ],
-              Text(
-                'Session actions',
-                style: XActText.caption.copyWith(color: XActColors.text4),
-              ),
-              const SizedBox(height: XActSpace.s2),
               XActBranding.buildSecondaryButton(
                 text: 'Back to Lobby',
                 icon: Icons.meeting_room_rounded,

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -80,6 +80,10 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
       await ApiService.instance.ensureRealtimeSessionSubscription(
         widget.sessionId,
       );
+      // Mark this player as present on the finished session. The host's rematch
+      // only copies still-connected members, so a player who leaves this screen
+      // (and unregisters) is not carried over into the new lobby as a ghost.
+      await ApiService.instance.registerCurrentMemberPresence();
     } catch (_) {
       // The subscription normally persists from the lobby; the listener below
       // still works if it is already in place.

--- a/xact_frontend/lib/screens/end_match_screen.dart
+++ b/xact_frontend/lib/screens/end_match_screen.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:xact_frontend/api/api_service.dart';
 import 'package:xact_frontend/api/models.dart';
 import 'package:xact_frontend/screens/start/start_screen.dart';
+import 'package:xact_frontend/screens/team/team_lobby.dart';
+import 'package:xact_frontend/services/app_session.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
 class EndMatchScreen extends StatefulWidget {
@@ -22,13 +26,22 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
 
   bool _loading = true;
   bool _working = false;
+  bool _migrating = false;
   GameSessionDetails? _sessionDetails;
   LobbySnapshot? _snapshot;
+  StreamSubscription<RealtimeEventEnvelope>? _rematchSub;
 
   @override
   void initState() {
     super.initState();
     _loadSummary();
+    _initRematchListener();
+  }
+
+  @override
+  void dispose() {
+    _rematchSub?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadSummary() async {
@@ -52,6 +65,92 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
         setState(() => _loading = false);
       }
     }
+  }
+
+  bool get _isHost {
+    final hostUserId = _sessionDetails?.hostUserId;
+    final currentUserId = AppSession.instance.currentUserId;
+    return hostUserId != null && currentUserId == hostUserId;
+  }
+
+  /// Keep listening on the finished session's channel so that when the host
+  /// starts a rematch, every client (host included) migrates into the new lobby.
+  Future<void> _initRematchListener() async {
+    try {
+      await ApiService.instance.ensureRealtimeSessionSubscription(
+        widget.sessionId,
+      );
+    } catch (_) {
+      // The subscription normally persists from the lobby; the listener below
+      // still works if it is already in place.
+    }
+
+    _rematchSub = ApiService.instance.realtimeEvents.listen((event) {
+      if (event.type == RealtimeEvents.rematchCreated) {
+        final payload = RematchCreatedPayload.fromJson(event.payload);
+        if (payload.finishedSessionId == widget.sessionId) {
+          _navigateToRematch(
+            sessionId: payload.newSessionId,
+            joinCode: payload.newJoinCode,
+            sessionName: payload.sessionName,
+            hostUserId: payload.hostUserId,
+          );
+        }
+      }
+    });
+  }
+
+  Future<void> _startRematch() async {
+    setState(() => _working = true);
+    try {
+      final rematch = await ApiService.instance.createRematch(widget.sessionId);
+      // Navigate straight from the response; other clients follow via the
+      // broadcast. The guard in _navigateToRematch prevents a double push when
+      // the host receives its own broadcast.
+      _navigateToRematch(
+        sessionId: rematch.sessionId,
+        joinCode: rematch.joinCode,
+        sessionName: rematch.sessionName,
+        hostUserId: rematch.hostUserId,
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _working = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not start a new lobby: $error')),
+      );
+    }
+  }
+
+  void _navigateToRematch({
+    required int sessionId,
+    required String joinCode,
+    required String sessionName,
+    required int hostUserId,
+  }) {
+    if (_migrating || !mounted) {
+      return;
+    }
+    _migrating = true;
+
+    final currentUserId = AppSession.instance.currentUserId;
+    // Point the session state at the new lobby and drop the finished session's
+    // membership; the lobby re-resolves the player's new membership on load.
+    AppSession.instance.setSession(sessionId: sessionId, joinCode: joinCode);
+    AppSession.instance.clearMembership();
+
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => GameLobbyScreen(
+          sessionId: sessionId,
+          gameCode: joinCode,
+          gameName: sessionName,
+          isLeader: currentUserId != null && currentUserId == hostUserId,
+        ),
+      ),
+    );
   }
 
   String? get _winnerTeamName {
@@ -489,10 +588,28 @@ class _EndMatchScreenState extends State<EndMatchScreen> {
                   ),
                 ),
               ],
+              if (_isHost) ...[
+                XActBranding.buildSecondaryButton(
+                  text: 'Back to the Lobby',
+                  icon: Icons.meeting_room_rounded,
+                  onPressed: (_working || _migrating) ? null : _startRematch,
+                  height: 54,
+                ),
+                const SizedBox(height: XActSpace.s3),
+              ] else if (!_loading) ...[
+                Padding(
+                  padding: const EdgeInsets.only(bottom: XActSpace.s3),
+                  child: Text(
+                    'Waiting for the host to start a new lobby…',
+                    textAlign: TextAlign.center,
+                    style: XActText.caption.copyWith(color: XActColors.text4),
+                  ),
+                ),
+              ],
               XActBranding.buildGhostButton(
                 text: 'Leave Lobby',
                 icon: Icons.logout_rounded,
-                onPressed: _working ? null : _leaveLobby,
+                onPressed: (_working || _migrating) ? null : _leaveLobby,
                 height: 54,
               ),
             ],

--- a/xact_frontend/lib/screens/game_screen.dart
+++ b/xact_frontend/lib/screens/game_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../api/api_service.dart';
 import '../api/models.dart';
 import 'end_match_screen.dart';
+import 'team/team_lobby.dart';
 import 'start/start_screen.dart';
 import 'team_screen.dart';
 import 'all_chat_screen.dart';
@@ -26,6 +27,7 @@ class _GameScreenState extends State<GameScreen> {
   bool _trackingInitCancelled = false;
   bool _allowDirectPop = false;
   bool _endMatchNavigationStarted = false;
+  bool _rematchNavigationStarted = false;
   bool _endingGame = false;
   Timer? _trackingRetryTimer;
   Timer? _sessionStatusPollTimer;
@@ -76,6 +78,8 @@ class _GameScreenState extends State<GameScreen> {
       _realtimeEventSub = ApiService.instance.realtimeEvents.listen((event) {
         if (event.type == RealtimeEvents.mrXCaught) {
           _onMrXCaught(MrXCaughtPayload.fromJson(event.payload));
+        } else if (event.type == RealtimeEvents.rematchCreated) {
+          _onRematchCreated(RematchCreatedPayload.fromJson(event.payload));
         }
       });
     } catch (_) {
@@ -303,6 +307,35 @@ class _GameScreenState extends State<GameScreen> {
 
     await Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => EndMatchScreen(sessionId: sessionId)),
+    );
+  }
+
+  /// The host started a rematch while this client was still in-game. Jump
+  /// straight into the new lobby instead of waiting for the status poll to
+  /// route through the end-match screen.
+  void _onRematchCreated(RematchCreatedPayload payload) {
+    if (_rematchNavigationStarted ||
+        _endMatchNavigationStarted ||
+        !mounted ||
+        payload.finishedSessionId != AppSession.instance.currentSessionId) {
+      return;
+    }
+
+    // Block the finished-session poll/navigation and tear down game timers.
+    _rematchNavigationStarted = true;
+    _endMatchNavigationStarted = true;
+    _trackingInitCancelled = true;
+    _trackingRetryTimer?.cancel();
+    _sessionStatusPollTimer?.cancel();
+    _realtimeEventSub?.cancel();
+    LocationService.instance.stopTracking();
+
+    openRematchLobby(
+      context,
+      sessionId: payload.newSessionId,
+      joinCode: payload.newJoinCode,
+      sessionName: payload.sessionName,
+      hostUserId: payload.hostUserId,
     );
   }
 

--- a/xact_frontend/lib/screens/game_screen.dart
+++ b/xact_frontend/lib/screens/game_screen.dart
@@ -78,6 +78,8 @@ class _GameScreenState extends State<GameScreen> {
       _realtimeEventSub = ApiService.instance.realtimeEvents.listen((event) {
         if (event.type == RealtimeEvents.mrXCaught) {
           _onMrXCaught(MrXCaughtPayload.fromJson(event.payload));
+        } else if (event.type == RealtimeEvents.gameSessionEnded) {
+          _onGameSessionEnded(GameSessionEndedPayload.fromJson(event.payload));
         } else if (event.type == RealtimeEvents.rematchCreated) {
           _onRematchCreated(RematchCreatedPayload.fromJson(event.payload));
         }
@@ -308,6 +310,16 @@ class _GameScreenState extends State<GameScreen> {
     await Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => EndMatchScreen(sessionId: sessionId)),
     );
+  }
+
+  /// The match ended (host pressed end). Open the end-match screen at once
+  /// instead of waiting for the next status poll to notice.
+  void _onGameSessionEnded(GameSessionEndedPayload payload) {
+    if (payload.sessionId != AppSession.instance.currentSessionId) {
+      return;
+    }
+
+    unawaited(_openEndMatchScreen());
   }
 
   /// The host started a rematch while this client was still in-game. Jump

--- a/xact_frontend/lib/screens/team/team_lobby.dart
+++ b/xact_frontend/lib/screens/team/team_lobby.dart
@@ -24,6 +24,34 @@ import 'package:xact_frontend/widgets/team/team_data.dart';
 import 'package:xact_frontend/widgets/team/team_overview_card.dart';
 import 'package:xact_frontend/widgets/xact_branding.dart';
 
+/// Switches session state to the freshly created rematch lobby and opens it,
+/// replacing the current screen. Shared by the game and end-match screens so
+/// every client migrates the same way the instant the host starts a rematch.
+void openRematchLobby(
+  BuildContext context, {
+  required int sessionId,
+  required String joinCode,
+  required String sessionName,
+  required int hostUserId,
+}) {
+  final currentUserId = AppSession.instance.currentUserId;
+  // Point session state at the new lobby and drop the finished session's
+  // membership; the lobby re-resolves the player's new membership on load.
+  AppSession.instance.setSession(sessionId: sessionId, joinCode: joinCode);
+  AppSession.instance.clearMembership();
+
+  Navigator.of(context).pushReplacement(
+    MaterialPageRoute(
+      builder: (_) => GameLobbyScreen(
+        sessionId: sessionId,
+        gameCode: joinCode,
+        gameName: sessionName,
+        isLeader: currentUserId != null && currentUserId == hostUserId,
+      ),
+    ),
+  );
+}
+
 class GameLobbyScreen extends StatefulWidget {
   final int sessionId;
   final String gameCode;

--- a/xact_frontend/lib/services/realtime_service.dart
+++ b/xact_frontend/lib/services/realtime_service.dart
@@ -333,6 +333,15 @@ final class RealtimeService {
         );
         break;
 
+      case RealtimeEvents.gameSessionEnded:
+        final payload = GameSessionEndedPayload.fromJson(envelope.payload);
+        _latestSnapshot = snapshot.copyWith(
+          status: payload.status,
+          startTime: payload.startTime,
+          endTime: payload.endTime,
+        );
+        break;
+
       case RealtimeEvents.locationLogRecorded:
         final payload = LocationLogRecordedPayload.fromJson(envelope.payload);
 

--- a/xact_frontend/pubspec.lock
+++ b/xact_frontend/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -356,18 +356,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   message_pack_dart:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   tuple:
     dependency: transitive
     description:


### PR DESCRIPTION
Implement a rematch endpoint to allow hosts to relaunch finished sessions, enabling players to auto-migrate to a new lobby. Refactor the end-match screen for improved layout and clarity, removing redundant elements and enhancing the user experience. Addressed issues with player migration and session state management to ensure a seamless transition.