### PR TITLE
fix: resolve infinite acquiring GPS loop on game start

### DIFF
--- a/xact_frontend/lib/services/location_service.dart
+++ b/xact_frontend/lib/services/location_service.dart
@@ -77,6 +77,10 @@ final class LocationService {
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
       if (!serviceEnabled) {
         final lastKnown = await Geolocator.getLastKnownPosition();
+        if (lastKnown != null) {
+          lastKnownPosition = lastKnown;
+          _positionController.add(lastKnown);
+        }
         return lastKnown;
       }
 
@@ -93,6 +97,10 @@ final class LocationService {
       // Timeout or platform error – fall back to last known fix if we have one.
       try {
         final lastKnown = await Geolocator.getLastKnownPosition();
+        if (lastKnown != null) {
+          lastKnownPosition = lastKnown;
+          _positionController.add(lastKnown);
+        }
         return lastKnown;
       } catch (_) {
         return null;
@@ -111,6 +119,18 @@ final class LocationService {
     if (!granted) {
       return;
     }
+
+    // Immediately broadcast the last known location so the UI loads instantly.
+    try {
+      final lastKnown = await Geolocator.getLastKnownPosition();
+      if (lastKnown != null) {
+        lastKnownPosition = lastKnown;
+        _positionController.add(lastKnown);
+      }
+    } catch (_) {}
+
+    // Force an initial fix to prevent "Acquiring GPS" loops on some devices.
+    unawaited(getCurrentPosition(timeLimit: const Duration(seconds: 5)));
 
     const locationSettings = LocationSettings(
       accuracy: LocationAccuracy.high,
@@ -152,6 +172,18 @@ final class LocationService {
     if (!granted) {
       return;
     }
+
+    // Immediately broadcast the last known location so the UI loads instantly.
+    try {
+      final lastKnown = await Geolocator.getLastKnownPosition();
+      if (lastKnown != null) {
+        lastKnownPosition = lastKnown;
+        _positionController.add(lastKnown);
+      }
+    } catch (_) {}
+
+    // Force an initial fix to prevent "Acquiring GPS" loops on some devices.
+    unawaited(getCurrentPosition(timeLimit: const Duration(seconds: 5)));
 
     const locationSettings = LocationSettings(
       accuracy: LocationAccuracy.high,


### PR DESCRIPTION
Fixes a bug where the game screen could get permanently stuck on the "Acquiring GPS..." loading overlay when starting a session, particularly indoors.                                                                                                                                               
                                                                                                                                                                           
  ### Root Cause                                                                                                                                                           
                                                                                                                                                                           
1.  getCurrentPosition  fetched a fallback location if the high-accuracy GPS fix timed out, but never broadcasted it to the UI stream.
2. The initial GPS live-stream relies on a 5-meter  distanceFilter , which suppresses the very first location event if the device is stationary on startup.
  
  ### Fix
  
- Immediately push the OS's last known location to the  _positionController  the moment  startTracking  or  startWatching  is called to instantly unblock the UI.        
- Fixed  getCurrentPosition  to properly add cached fallback locations to the UI stream when a timeout occurs, preventing infinite hangs.